### PR TITLE
fix(ipynb): update fold fill character configuration

### DIFF
--- a/ftplugin/ipynb.lua
+++ b/ftplugin/ipynb.lua
@@ -7,5 +7,5 @@ vim.wo.foldexpr = 'v:lua.require("ipynb.folding").foldexpr()'
 vim.wo.foldtext = 'v:lua.require("ipynb.folding").foldtext()'
 vim.wo.foldenable = true
 vim.wo.foldlevel = 99 -- Start all unfolded
-vim.wo.fillchars = vim.wo.fillchars .. ",fold: " -- Clean fold fill
+vim.opt_local.fillchars:append({ fold = " " }) -- Clean fold fill
 


### PR DESCRIPTION
## Problem
When creating a notebook via `:NotebookCreate`, an error occurs:
`E474: Invalid argument` in `ftplugin/ipynb.lua:10`.

**Cause:**
The original code:
```lua
vim.wo.fillchars = vim.wo.fillchars .. ",fold: "
```

If `vim.wo.fillchars` is empty (which is common for new buffers), the result becomes ",fold: ". Neovim rejects option values starting with a comma.

## Solution

I replaced the manual string concatenation with the safer vim.opt_local API:

```lua
vim.opt_local.fillchars:append({ fold = " " })
```

This correctly handles appending the option regardless of whether fillchars is empty or populated.

---

## Suggestion for Improvement

While working on this, I also noticed that the current folded cell text is quite generic.
I suggest improving the `foldtext` function to display the first line of the cell content as a preview when folded. This would make navigation much easier. It would look like this:

<img width="960" height="202" alt="图片" src="https://github.com/user-attachments/assets/b8cdee57-9e24-4615-8984-e729ae9f0287" />

<img width="922" height="140" alt="图片" src="https://github.com/user-attachments/assets/0d47899d-70cf-4e1d-a397-a23d14caeacb" />

And this is my implementation in `lua/ipynb/folding.lua`:

<img width="666" height="284" alt="图片" src="https://github.com/user-attachments/assets/61386a7c-5308-4cc7-81a6-d9104fd4286d" />

If you approve, I can create a new PR for this.