### PR TITLE
feat(folding): enhance foldtext with cell preview and icon

### DIFF
--- a/lua/ipynb/folding.lua
+++ b/lua/ipynb/folding.lua
@@ -23,9 +23,16 @@ end
 
 ---Custom foldtext showing line count
 ---@return string
+local devicons_ok = pcall(require, 'nvim-web-devicons')
 function M.foldtext()
   local line_count = vim.v.foldend - vim.v.foldstart + 1
-  return string.format('--- %d lines ---', line_count)
+  local first_line = vim.fn.getline(vim.v.foldstart)
+  first_line = vim.trim(first_line)
+  if #first_line > 60 then
+    first_line = first_line:sub(1, 60) .. '...'
+  end
+  local icon = devicons_ok and '' or '⬍'
+  return string.format('%s  (%s %d lines)', first_line, icon, line_count)
 end
 
 ---Custom foldexpr using treesitter to find cell_content nodes


### PR DESCRIPTION
### Problem
Currently, when a cell is folded, the fold text only displays the number of folded lines (e.g., "--- 4 lines ---"). This generic display hides the context of the cell's contents, making it difficult to navigate large notebooks or identify specific cells without unfolding them to check what is inside.

### Solution
I have enhanced the fold text configuration to include the content of the first line of the folded cell.
- When a cell is folded, the fold line now renders the text from the first line of the code or markdown block.
- This provides immediate context for the cell while keeping the interface clean and collapsed.

### Screenshots
<img width="871" height="157" alt="图片" src="https://github.com/user-attachments/assets/22a6bd5f-7310-4e4b-a175-45295f9e12ce" />

| Before (Only line count) | After (First line content) |
| :---: | :---: |
| <img width="345" height="138" alt="图片" src="https://github.com/user-attachments/assets/8f96b7fc-c879-496e-958b-168382436b77" /> | <img width="762" height="105" alt="图片" src="https://github.com/user-attachments/assets/27ab2d47-17fa-4086-9b1f-b30e0ace9bdf" /> |

### Test

- OS: Arch Linux
- Neovim: v0.11.5
- Test command: `./tests/run_all.sh`

<details>
<summary>Click to expand test details</summary>

```
Bootstrap already present; skipping. Set IPYNB_TEST_FORCE_BOOTSTRAP=1 to force.
Bootstrapping gopls via go install...
Running ipynb.nvim test suite
==============================
>>> Running test_cells...
The `require('lspconfig')` "framework" is deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead.
Feature will be removed in nvim-lspconfig v3.0.0
stack traceback:
  ...t/share/ipynb-test/lazy/nvim-lspconfig/lua/lspconfig.lua:81: in function '__index'
  ..._repositories/nvim_dev/ipynb.nvim/tests/minimal_init.lua:111: in main chunk
============================================================
Running cell boundary tests
============================================================
  PASS: cell_boundaries_after_edit
  PASS: get_cell_at_line_accuracy
  PASS: content_vs_full_range
  PASS: boundaries_preserved_through_undo
  PASS: shadow_facade_line_sync
  PASS: cell_count_consistency
  PASS: mixed_cell_type_boundaries
============================================================
Results: 7 passed, 0 failed
>>> Running test_modified...
============================================================
The `require('lspconfig')` "framework" is deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead.
Feature will be removed in nvim-lspconfig v3.0.0
stack traceback:
  ...t/share/ipynb-test/lazy/nvim-lspconfig/lua/lspconfig.lua:81: in function '__index'
  ..._repositories/nvim_dev/ipynb.nvim/tests/minimal_init.lua:111: in main chunk
============================================================
Running buffer modified state tests
============================================================
  PASS: no_modified_on_enter_exit
  PASS: no_undo_entry_without_changes
  PASS: edit_buf_modified_cleared_on_exit
  PASS: reopen_cell_no_spurious_state
  PASS: insert_mode_no_typing_no_undo
  PASS: changedtick_prevents_spurious_sync
============================================================
Results: 6 passed, 0 failed
>>> Running test_undo...
============================================================
The `require('lspconfig')` "framework" is deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead.
Feature will be removed in nvim-lspconfig v3.0.0
stack traceback:
  ...t/share/ipynb-test/lazy/nvim-lspconfig/lua/lspconfig.lua:81: in function '__index'
  ..._repositories/nvim_dev/ipynb.nvim/tests/minimal_init.lua:111: in main chunk
============================================================
Running undo behavior tests
============================================================
  PASS: single_insert_session_undo
  PASS: multi_cell_undo_chain
  PASS: undo_within_edit_float
  PASS: undo_redo_cycle
  PASS: multiple_undo_redo_cycles
  PASS: undo_isolation_between_cells
============================================================
Results: 6 passed, 0 failed
>>> Running test_io...
============================================================
The `require('lspconfig')` "framework" is deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead.
Feature will be removed in nvim-lspconfig v3.0.0
stack traceback:
  ...t/share/ipynb-test/lazy/nvim-lspconfig/lua/lspconfig.lua:81: in function '__index'
  ..._repositories/nvim_dev/ipynb.nvim/tests/minimal_init.lua:111: in main chunk
============================================================
Running I/O round-trip tests
============================================================
  PASS: source_splitting_matches_nbformat
  PASS: roundtrip_preserves_cell_source
  PASS: roundtrip_preserves_cell_types
  PASS: roundtrip_preserves_kernelspec
  PASS: roundtrip_preserves_rich_metadata
  PASS: roundtrip_preserves_cell_ids
  PASS: roundtrip_preserves_cell_metadata
  PASS: roundtrip_preserves_outputs
  PASS: roundtrip_preserves_execution_count
  PASS: roundtrip_handles_empty_cells
  PASS: roundtrip_preserves_unicode
  PASS: roundtrip_handles_trailing_newlines
  PASS: roundtrip_preserves_nbformat
  PASS: written_notebook_is_valid_json
  PASS: can_read_written_notebook
  PASS: all_fixtures_roundtrip
  PASS: jupytext_format_roundtrip
  PASS: nbformat_test4_5_roundtrip
  PASS: nbformat_test4_roundtrip_autoupgrade
  PASS: nbformat_jupyter_metadata_roundtrip
  PASS: nbformat_custom_mime_roundtrip
  PASS: nbformat_tracebacks_roundtrip
  PASS: nbformat_test4_5_full_json_equality
  PASS: nbformat_jupyter_metadata_full_json_equality
  PASS: nbformat_custom_mime_full_json_equality
  PASS: nbformat_tracebacks_full_json_equality
  PASS: all_nbformat_fixtures_roundtrip
============================================================
Results: 27 passed, 0 failed
>>> Running test_lsp...
============================================================
The `require('lspconfig')` "framework" is deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead.
Feature will be removed in nvim-lspconfig v3.0.0
stack traceback:
  ...t/share/ipynb-test/lazy/nvim-lspconfig/lua/lspconfig.lua:81: in function '__index'
  ..._repositories/nvim_dev/ipynb.nvim/tests/minimal_init.lua:111: in main chunk
============================================================
Running LSP proxy tests
============================================================
  PASS: lsp_clients_available_for_facade
  PASS: lsp_clients_available_for_edit_buffer
  PASS: diagnostics_in_facade
  PASS: diagnostics_in_edit_buffer
position_encoding param is required in vim.lsp.util.make_position_params. Defaulting to position encoding of the first client.
warning: multiple different client offset_encodings detected for buffer, vim.lsp.util._get_offset_encoding() uses the offset_encoding from the first client
  PASS: position_params_use_shadow_uri
  PASS: buf_request_redirects_to_shadow
  PASS: document_symbol_uris_facade
  PASS: goto_definition_from_facade
  PASS: goto_definition_from_edit
  PASS: find_references_from_facade
  PASS: find_references_from_edit
  PASS: hover_from_facade
  PASS: hover_from_edit
  PASS: document_highlight_facade_handler
  PASS: inlay_hint_facade_handler
  SKIP: selectionRange not supported by LSP
  PASS: selection_range_facade_handler
  PASS: vim_lsp_buf_definition_from_facade
  PASS: vim_lsp_buf_declaration_from_facade
  PASS: vim_lsp_buf_type_definition_from_facade
No locations found
  PASS: vim_lsp_buf_implementation_from_facade
  PASS: shadow_buffer_content
  PASS: format_cell_from_edit_float
============================================================
Results: 22 passed, 0 failed
>>> Running test_lsp_go...
============================================================
The `require('lspconfig')` "framework" is deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead.
Feature will be removed in nvim-lspconfig v3.0.0
stack traceback:
  ...t/share/ipynb-test/lazy/nvim-lspconfig/lua/lspconfig.lua:81: in function '__index'
  ..._repositories/nvim_dev/ipynb.nvim/tests/minimal_init.lua:95: in main chunk
============================================================
Running LSP Go tests
============================================================
Client gopls quit with exit code 1 and signal 0. Check log for errors: /home/ricardo/git_repositories/nvim_dev/ipynb.nvim/tests/.nvim-test/state/ipynb-test/lsp.log
  WARN: No Go LSP server found. gopls tests require:
        - gopls in PATH, OR
        - IPYNB_TEST_LSP_BIN set to gopls
============================================================
Results: 0 passed, 0 failed (gopls tests skipped)
>>> Running test_treesitter_autoinstall...
============================================================
The `require('lspconfig')` "framework" is deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead.
Feature will be removed in nvim-lspconfig v3.0.0
stack traceback:
  ...t/share/ipynb-test/lazy/nvim-lspconfig/lua/lspconfig.lua:81: in function '__index'
  ..._repositories/nvim_dev/ipynb.nvim/tests/minimal_init.lua:111: in main chunk
==============================
All test suites completed
Auto-install succeeded.
```

</details>