### PR TITLE
fix(ipynb): remove global undo/redo keymaps from edit mode

### DIFF
--- a/lua/ipynb/edit.lua
+++ b/lua/ipynb/edit.lua
@@ -472,7 +472,7 @@ function M.setup_sync(state, buf)
     end,
   })
 
-  -- Also sync facade on TextChanged (normal mode changes like dd, p, etc.)
+  -- Also sync facade on TextChanged (normal mode changes like dd, p, undo, redo, etc.)
   vim.api.nvim_create_autocmd('TextChanged', {
     group = group,
     buffer = buf,
@@ -568,15 +568,6 @@ function M.setup_edit_keymaps(state)
   vim.keymap.set('n', '<C-k>', function()
     M.edit_prev_cell(state)
   end, vim.tbl_extend('force', opts, { desc = 'Edit previous cell' }))
-
-  -- Global undo/redo (operates on facade buffer)
-  vim.keymap.set('n', 'u', function()
-    M.global_undo(state)
-  end, vim.tbl_extend('force', opts, { desc = 'Global undo' }))
-
-  vim.keymap.set('n', '<C-r>', function()
-    M.global_redo(state)
-  end, vim.tbl_extend('force', opts, { desc = 'Global redo' }))
 
   -- Execute cell and stay in edit mode
   vim.keymap.set({ 'n', 'i' }, '<C-CR>', function()


### PR DESCRIPTION
### Problem

When editing cell content in the `edit buffer`, the behavior of Undo (`u`) and Redo (`<C-r>`) is unexpected.

Steps:

1.  User enters the `edit buffer` by `i`, types `aaa`, presses `<esc>o` (new line), types `bbb`, presses `<esc>o` (new line), and types `ccc`, presses `<esc>` to normal mode.
2.  User presses `u` to undo.
 
**Expected:** Only the last operation should be undone (deleting `ccc`).

**Actual:** It triggers `global_undo()`, performing an undo within the context of the `facade buffer`. This often reverts the last full synchronization of the cell, causing all recent content to be lost.
https://github.com/ajbucci/ipynb.nvim/blob/9f0e16fded3d65c842ab55921b45e380f5b8592c/lua/ipynb/edit.lua#L750-L752

> Additionally, `<C-r>` does not work as Redo within the `edit buffer`.

### Cause

In `ipynb.edit.setup_edit_keymaps()`, `u` and `<C-r>` in the `edit buffer` are explicitly mapped to `global_undo()` and `global_redo()`. 

https://github.com/ajbucci/ipynb.nvim/blob/9f0e16fded3d65c842ab55921b45e380f5b8592c/lua/ipynb/edit.lua#L572-L579

These functions are designed for global undo/redo operations on the `facade buffer` and should not be used within the specific context of the `edit buffer`.

### Solution

Remove the custom mappings for `u` and `<C-r>` in the `edit buffer`, allowing these keys to revert to Neovim's default undo/redo behavior.

Why this works:

1.  By removing the custom mappings, `u` and `<C-r>` will utilize the default undo/redo functionality, operating on the `edit buffer`'s local undo tree.
2.  Undo/Redo operations trigger the `TextChanged` event.
4.  The existing `TextChanged` autocmd automatically syncs these changes back to the `facade buffer`.
https://github.com/ajbucci/ipynb.nvim/blob/9f0e16fded3d65c842ab55921b45e380f5b8592c/lua/ipynb/edit.lua#L476-L504
5.  This approach preserves the synchronization mechanism between the `edit buffer` and the `facade buffer` without breaking it.

Verification:

- Undo operations in the `edit buffer` incrementally revert user edits as expected.
- Changes are automatically synced to the `facade buffer` via the `TextChanged` event.
- `u` in the `facade buffer` still triggers global undo (retaining original behavior).

### Test

- OS: Arch Linux
- Neovim: v0.11.5
- Test command: `./tests/run_all.sh`

<details>

```
Bootstrap already present; skipping. Set IPYNB_TEST_FORCE_BOOTSTRAP=1 to force.
Bootstrapping gopls via go install...
Running ipynb.nvim test suite
==============================
>>> Running test_cells...
The `require('lspconfig')` "framework" is deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead.
Feature will be removed in nvim-lspconfig v3.0.0
stack traceback:
  ...t/share/ipynb-test/lazy/nvim-lspconfig/lua/lspconfig.lua:81: in function '__index'
  ..._repositories/nvim_dev/ipynb.nvim/tests/minimal_init.lua:111: in main chunk
============================================================
Running cell boundary tests
============================================================
  PASS: cell_boundaries_after_edit
  PASS: get_cell_at_line_accuracy
  PASS: content_vs_full_range
  PASS: boundaries_preserved_through_undo
  PASS: shadow_facade_line_sync
  PASS: cell_count_consistency
  PASS: mixed_cell_type_boundaries
============================================================
Results: 7 passed, 0 failed
>>> Running test_modified...
============================================================
The `require('lspconfig')` "framework" is deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead.
Feature will be removed in nvim-lspconfig v3.0.0
stack traceback:
  ...t/share/ipynb-test/lazy/nvim-lspconfig/lua/lspconfig.lua:81: in function '__index'
  ..._repositories/nvim_dev/ipynb.nvim/tests/minimal_init.lua:111: in main chunk
============================================================
Running buffer modified state tests
============================================================
  PASS: no_modified_on_enter_exit
  PASS: no_undo_entry_without_changes
  PASS: edit_buf_modified_cleared_on_exit
  PASS: reopen_cell_no_spurious_state
  PASS: insert_mode_no_typing_no_undo
  PASS: changedtick_prevents_spurious_sync
============================================================
Results: 6 passed, 0 failed
>>> Running test_undo...
============================================================
The `require('lspconfig')` "framework" is deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead.
Feature will be removed in nvim-lspconfig v3.0.0
stack traceback:
  ...t/share/ipynb-test/lazy/nvim-lspconfig/lua/lspconfig.lua:81: in function '__index'
  ..._repositories/nvim_dev/ipynb.nvim/tests/minimal_init.lua:111: in main chunk
============================================================
Running undo behavior tests
============================================================
  PASS: single_insert_session_undo
  PASS: multi_cell_undo_chain
  PASS: undo_within_edit_float
  PASS: undo_redo_cycle
  PASS: multiple_undo_redo_cycles
  PASS: undo_isolation_between_cells
============================================================
Results: 6 passed, 0 failed
>>> Running test_io...
============================================================
The `require('lspconfig')` "framework" is deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead.
Feature will be removed in nvim-lspconfig v3.0.0
stack traceback:
  ...t/share/ipynb-test/lazy/nvim-lspconfig/lua/lspconfig.lua:81: in function '__index'
  ..._repositories/nvim_dev/ipynb.nvim/tests/minimal_init.lua:111: in main chunk
============================================================
Running I/O round-trip tests
============================================================
  PASS: source_splitting_matches_nbformat
  PASS: roundtrip_preserves_cell_source
  PASS: roundtrip_preserves_cell_types
  PASS: roundtrip_preserves_kernelspec
  PASS: roundtrip_preserves_rich_metadata
  PASS: roundtrip_preserves_cell_ids
  PASS: roundtrip_preserves_cell_metadata
  PASS: roundtrip_preserves_outputs
  PASS: roundtrip_preserves_execution_count
  PASS: roundtrip_handles_empty_cells
  PASS: roundtrip_preserves_unicode
  PASS: roundtrip_handles_trailing_newlines
  PASS: roundtrip_preserves_nbformat
  PASS: written_notebook_is_valid_json
  PASS: can_read_written_notebook
  PASS: all_fixtures_roundtrip
  PASS: jupytext_format_roundtrip
  PASS: nbformat_test4_5_roundtrip
  PASS: nbformat_test4_roundtrip_autoupgrade
  PASS: nbformat_jupyter_metadata_roundtrip
  PASS: nbformat_custom_mime_roundtrip
  PASS: nbformat_tracebacks_roundtrip
  PASS: nbformat_test4_5_full_json_equality
  PASS: nbformat_jupyter_metadata_full_json_equality
  PASS: nbformat_custom_mime_full_json_equality
  PASS: nbformat_tracebacks_full_json_equality
  PASS: all_nbformat_fixtures_roundtrip
============================================================
Results: 27 passed, 0 failed
>>> Running test_lsp...
============================================================
The `require('lspconfig')` "framework" is deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead.
Feature will be removed in nvim-lspconfig v3.0.0
stack traceback:
  ...t/share/ipynb-test/lazy/nvim-lspconfig/lua/lspconfig.lua:81: in function '__index'
  ..._repositories/nvim_dev/ipynb.nvim/tests/minimal_init.lua:111: in main chunk
============================================================
Running LSP proxy tests
============================================================
  PASS: lsp_clients_available_for_facade
  PASS: lsp_clients_available_for_edit_buffer
  PASS: diagnostics_in_facade
  PASS: diagnostics_in_edit_buffer
position_encoding param is required in vim.lsp.util.make_position_params. Defaulting to position encoding of the first client.
warning: multiple different client offset_encodings detected for buffer, vim.lsp.util._get_offset_encoding() uses the offset_encoding from the first client
  PASS: position_params_use_shadow_uri
  PASS: buf_request_redirects_to_shadow
  PASS: document_symbol_uris_facade
  PASS: goto_definition_from_facade
  PASS: goto_definition_from_edit
  PASS: find_references_from_facade
  PASS: find_references_from_edit
  PASS: hover_from_facade
  PASS: hover_from_edit
  PASS: document_highlight_facade_handler
  PASS: inlay_hint_facade_handler
  SKIP: selectionRange not supported by LSP
  PASS: selection_range_facade_handler
  PASS: vim_lsp_buf_definition_from_facade
  PASS: vim_lsp_buf_declaration_from_facade
  PASS: vim_lsp_buf_type_definition_from_facade
No locations found
  PASS: vim_lsp_buf_implementation_from_facade
  PASS: shadow_buffer_content
  PASS: format_cell_from_edit_float
============================================================
Results: 22 passed, 0 failed
>>> Running test_lsp_go...
============================================================
The `require('lspconfig')` "framework" is deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead.
Feature will be removed in nvim-lspconfig v3.0.0
stack traceback:
  ...t/share/ipynb-test/lazy/nvim-lspconfig/lua/lspconfig.lua:81: in function '__index'
  ..._repositories/nvim_dev/ipynb.nvim/tests/minimal_init.lua:95: in main chunk
============================================================
Running LSP Go tests
============================================================
Client gopls quit with exit code 1 and signal 0. Check log for errors: /home/ricardo/git_repositories/nvim_dev/ipynb.nvim/tests/.nvim-test/state/ipynb-test/lsp.log
  WARN: No Go LSP server found. gopls tests require:
        - gopls in PATH, OR
        - IPYNB_TEST_LSP_BIN set to gopls
============================================================
Results: 0 passed, 0 failed (gopls tests skipped)
>>> Running test_treesitter_autoinstall...
============================================================
The `require('lspconfig')` "framework" is deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead.
Feature will be removed in nvim-lspconfig v3.0.0
stack traceback:
  ...t/share/ipynb-test/lazy/nvim-lspconfig/lua/lspconfig.lua:81: in function '__index'
  ..._repositories/nvim_dev/ipynb.nvim/tests/minimal_init.lua:111: in main chunk
==============================
All test suites completed
Auto-install succeeded.
```

</details>
