### PR TITLE
fix: 7 bug fixes for editing and running notebooks

### DIFF
--- a/lua/ipynb/edit.lua
+++ b/lua/ipynb/edit.lua
@@ -59,6 +59,9 @@ function M.unregister_edit_buffer(edit_buf)
 end
 
 -- Install change tracking error suppression (called once)
+-- Uses vim.lsp._changetracking (internal API) when available, with pcall fallback.
+-- If the internal API changes in a future Neovim version, the wrapper silently
+-- becomes a no-op and set_facade_lines() still catches errors via its own pcall.
 local _changetracking_wrapped = false
 local function install_changetracking_wrapper()
   if _changetracking_wrapped then
@@ -66,10 +69,15 @@ local function install_changetracking_wrapper()
   end
   _changetracking_wrapped = true
 
-  -- Wrap the on_bytes handler that LSP sets up
-  -- We intercept at the point where changes are sent
-  local ct = vim.lsp._changetracking
-  if ct and ct.send_changes then
+  local ok, ct = pcall(function()
+    return vim.lsp._changetracking
+  end)
+  if not ok or not ct then
+    return
+  end
+
+  -- Try the current (0.10+) API shape: _changetracking.send_changes
+  if type(ct) == 'table' and type(ct.send_changes) == 'function' then
     local orig_send_changes = ct.send_changes
     ---@diagnostic disable-next-line: duplicate-set-field
     ct.send_changes = function(bufnr, ...)

--- a/lua/ipynb/kernel.lua
+++ b/lua/ipynb/kernel.lua
@@ -9,7 +9,7 @@ local M = {}
 ---@field kernel_id string|nil Kernel ID
 ---@field kernel_name string Kernel name (e.g., "python3")
 ---@field execution_state string Current state: "idle", "busy", "starting"
----@field pending_cells table<string, {cell_idx: number}> Cells waiting for execution
+---@field pending_cells table<string, {cell_idx: number}> Cells waiting for execution (keyed by cell.id)
 ---@field callbacks table Async operation callbacks
 
 ---Create a new kernel state for a notebook
@@ -53,14 +53,31 @@ local function send_command(state, cmd)
   return true
 end
 
+---Find cell index by cell ID
+---@param state NotebookState
+---@param cell_id string
+---@return number|nil cell_idx
+local function find_cell_by_id(state, cell_id)
+  if not cell_id or not state.cells then
+    return nil
+  end
+  for i, cell in ipairs(state.cells) do
+    if cell.id == cell_id then
+      return i
+    end
+  end
+  return nil
+end
+
 ---Update a cell field and re-render visuals
 ---@param state NotebookState
----@param cell_idx number
+---@param cell_id string Cell ID to look up
 ---@param field string
 ---@param value any
-local function update_cell_field(state, cell_idx, field, value)
+local function update_cell_field(state, cell_id, field, value)
   vim.schedule(function()
-    if state and state.cells and state.cells[cell_idx] then
+    local cell_idx = find_cell_by_id(state, cell_id)
+    if cell_idx then
       state.cells[cell_idx][field] = value
       require("ipynb.visuals").render_all(state)
     end
@@ -161,26 +178,30 @@ local function handle_message(state, msg)
 
   elseif msg_type == "status" then
     kernel.execution_state = msg.state or "idle"
-    if msg.cell_idx and type(msg.cell_idx) == "number" then
-      update_cell_field(state, msg.cell_idx, "execution_state", msg.state)
+    local cell_id = msg.cell_id
+    if cell_id then
+      update_cell_field(state, cell_id, "execution_state", msg.state)
       if msg.state == "idle" then
-        kernel.pending_cells[msg.cell_idx] = nil
+        kernel.pending_cells[cell_id] = nil
       end
     end
 
   elseif msg_type == "execute_input" then
-    if msg.cell_idx and msg.execution_count then
-      update_cell_field(state, msg.cell_idx, "execution_count", msg.execution_count)
+    local cell_id = msg.cell_id
+    if cell_id and msg.execution_count then
+      update_cell_field(state, cell_id, "execution_count", msg.execution_count)
     end
 
   elseif msg_type == "output" then
-    if msg.cell_idx and msg.output then
+    local cell_id = msg.cell_id
+    if cell_id and msg.output then
       vim.schedule(function()
-        if state.cells and state.cells[msg.cell_idx] then
-          local cell = state.cells[msg.cell_idx]
+        local cell_idx = find_cell_by_id(state, cell_id)
+        if cell_idx then
+          local cell = state.cells[cell_idx]
           cell.outputs = cell.outputs or {}
           table.insert(cell.outputs, msg.output)
-          require("ipynb.output").render_outputs(state, msg.cell_idx)
+          require("ipynb.output").render_outputs(state, cell_idx)
         end
       end)
     end
@@ -492,7 +513,7 @@ function M.execute(state, cell_idx)
   require("ipynb.output").clear_outputs(state, cell_idx)
 
   cell.execution_state = "busy"
-  state.kernel.pending_cells[cell_idx] = { cell_idx = cell_idx }
+  state.kernel.pending_cells[cell.id] = { cell_idx = cell_idx }
 
   require("ipynb.visuals").render_all(state)
 
@@ -500,6 +521,7 @@ function M.execute(state, cell_idx)
     action = "execute",
     code = cell.source,
     cell_idx = cell_idx,
+    cell_id = cell.id,
   })
 end
 

--- a/lua/ipynb/lsp/format.lua
+++ b/lua/ipynb/lsp/format.lua
@@ -300,6 +300,9 @@ function M.format_cell(state, cell_idx, callback)
     return
   end
 
+  -- Flush any pending debounced shadow write before formatting
+  require('ipynb.lsp.shadow').flush_shadow_write(state)
+
   -- Build formatting request params
   local params = {
     textDocument = { uri = vim.uri_from_fname(state.shadow_path) },

--- a/lua/ipynb/lsp/init.lua
+++ b/lua/ipynb/lsp/init.lua
@@ -31,6 +31,7 @@ M.create_shadow = shadow.create_shadow
 M.attach_lsp = shadow.attach_lsp
 M.refresh_shadow = shadow.refresh_shadow
 M.sync_shadow_region = shadow.sync_shadow_region
+M.flush_shadow_write = shadow.flush_shadow_write
 
 -- Re-export diagnostics functions
 M.setup_diagnostics_proxy = diagnostics.setup_diagnostics_proxy

--- a/lua/ipynb/lsp/navigation.lua
+++ b/lua/ipynb/lsp/navigation.lua
@@ -131,9 +131,10 @@ function M.install()
     end
 
     -- Check if we're in an edit float and need to close it
-    if state and state.edit_state and state.edit_state.buf == current_buf then
-      local edit = state.edit_state
-      local parent_win = edit.parent_win
+    -- Capture flag BEFORE closing so jump_to_facade_and_edit can re-open it
+    local was_in_edit = state and state.edit_state and state.edit_state.buf == current_buf
+    if was_in_edit then
+      local parent_win = state.edit_state.parent_win
 
       -- Close the edit float
       require('ipynb.edit').close(state)
@@ -164,9 +165,8 @@ function M.install()
       vim.api.nvim_win_set_cursor(0, { facade_line, col })
 
       -- Re-enter edit float at the target location
-      -- NOTE: Only do this if we were in an edit float before navigation
+      -- Only do this if we were in an edit float before navigation
       -- If navigating from facade buffer, don't auto-open edit float
-      local was_in_edit = target_state.edit_state ~= nil
       if was_in_edit then
         vim.schedule(function()
           pcall(function()

--- a/lua/ipynb/lsp/shadow.lua
+++ b/lua/ipynb/lsp/shadow.lua
@@ -4,6 +4,28 @@
 
 local M = {}
 
+-- Debounce timer for shadow file writes (avoids disk I/O on every keystroke)
+local write_timer = nil
+local WRITE_DEBOUNCE_MS = 200
+
+---Schedule a debounced write of shadow buffer to disk
+---@param shadow_buf number Shadow buffer number
+---@param shadow_path string Path to shadow file
+local function schedule_shadow_write(shadow_buf, shadow_path)
+  if write_timer then
+    vim.fn.timer_stop(write_timer)
+  end
+  write_timer = vim.fn.timer_start(WRITE_DEBOUNCE_MS, function()
+    write_timer = nil
+    vim.schedule(function()
+      if vim.api.nvim_buf_is_valid(shadow_buf) then
+        local all_lines = vim.api.nvim_buf_get_lines(shadow_buf, 0, -1, false)
+        vim.fn.writefile(all_lines, shadow_path)
+      end
+    end)
+  end)
+end
+
 ---Get language info from notebook metadata
 ---@param state NotebookState
 ---@return string language (e.g., "python", "julia", "r")
@@ -239,12 +261,24 @@ function M.sync_shadow_region(state, start_line, old_end_line, new_lines, cell_t
 
   vim.api.nvim_buf_set_lines(state.shadow_buf, start_line, old_end_line, false, shadow_lines)
 
-  -- Update temp file for LSP
-  local all_lines = vim.api.nvim_buf_get_lines(state.shadow_buf, 0, -1, false)
-  vim.fn.writefile(all_lines, state.shadow_path)
+  -- Debounce disk write (LSP reads from buffer, only some servers need the file)
+  schedule_shadow_write(state.shadow_buf, state.shadow_path)
 
   -- Clear modified to prevent save warnings
   vim.bo[state.shadow_buf].modified = false
+end
+
+---Flush any pending debounced shadow file write immediately
+---Call this before operations that need the file on disk (e.g., save, format)
+function M.flush_shadow_write(state)
+  if write_timer then
+    vim.fn.timer_stop(write_timer)
+    write_timer = nil
+  end
+  if state.shadow_buf and vim.api.nvim_buf_is_valid(state.shadow_buf) and state.shadow_path then
+    local all_lines = vim.api.nvim_buf_get_lines(state.shadow_buf, 0, -1, false)
+    vim.fn.writefile(all_lines, state.shadow_path)
+  end
 end
 
 return M

--- a/lua/ipynb/output.lua
+++ b/lua/ipynb/output.lua
@@ -49,7 +49,11 @@ function M.render_output(output)
 
   if output.output_type == 'stream' then
     local text = to_string(output.text)
-    for line in text:gmatch('[^\n]+') do
+    -- Remove single trailing newline (output formatting), but preserve intentional blank lines
+    if text:sub(-1) == '\n' then
+      text = text:sub(1, -2)
+    end
+    for _, line in ipairs(vim.split(text, '\n', { plain = true })) do
       table.insert(lines, { { line, 'IpynbOutput' } })
     end
   elseif output.output_type == 'execute_result' then
@@ -119,7 +123,11 @@ function M.build_output_text(cell)
   for _, output in ipairs(cell.outputs) do
     if output.output_type == 'stream' then
       local text = to_string(output.text)
-      for line in text:gmatch('[^\n]+') do
+      -- Remove single trailing newline (output formatting), but preserve intentional blank lines
+      if text:sub(-1) == '\n' then
+        text = text:sub(1, -2)
+      end
+      for _, line in ipairs(vim.split(text, '\n', { plain = true })) do
         table.insert(lines, line)
       end
     elseif output.output_type == 'execute_result' then

--- a/python/kernel_bridge.py
+++ b/python/kernel_bridge.py
@@ -139,19 +139,25 @@ class KernelBridge:
         # Find the cell this message belongs to
         exec_info = self.pending_executions.get(msg_id, {})
         cell_idx = exec_info.get("cell_idx")
+        cell_id = exec_info.get("cell_id")
 
         if msg_type == "status":
             execution_state = content.get("execution_state", "")
             self.send_message({
                 "type": "status",
                 "state": execution_state,
-                "cell_idx": cell_idx
+                "cell_idx": cell_idx,
+                "cell_id": cell_id
             })
+            # Clean up pending_executions when execution completes
+            if execution_state == "idle" and msg_id in self.pending_executions:
+                del self.pending_executions[msg_id]
 
         elif msg_type == "stream":
             self.send_message({
                 "type": "output",
                 "cell_idx": cell_idx,
+                "cell_id": cell_id,
                 "output": {
                     "output_type": "stream",
                     "name": content.get("name", "stdout"),
@@ -163,6 +169,7 @@ class KernelBridge:
             self.send_message({
                 "type": "output",
                 "cell_idx": cell_idx,
+                "cell_id": cell_id,
                 "output": {
                     "output_type": "execute_result",
                     "execution_count": content.get("execution_count"),
@@ -175,6 +182,7 @@ class KernelBridge:
             self.send_message({
                 "type": "output",
                 "cell_idx": cell_idx,
+                "cell_id": cell_id,
                 "output": {
                     "output_type": "display_data",
                     "data": content.get("data", {}),
@@ -186,6 +194,7 @@ class KernelBridge:
             self.send_message({
                 "type": "output",
                 "cell_idx": cell_idx,
+                "cell_id": cell_id,
                 "output": {
                     "output_type": "error",
                     "ename": content.get("ename", "Error"),
@@ -199,10 +208,11 @@ class KernelBridge:
             self.send_message({
                 "type": "execute_input",
                 "cell_idx": cell_idx,
+                "cell_id": cell_id,
                 "execution_count": content.get("execution_count")
             })
 
-    def execute(self, code: str, cell_idx: int, user_expressions: Optional[Dict[str, str]] = None) -> Optional[str]:
+    def execute(self, code: str, cell_idx: int, user_expressions: Optional[Dict[str, str]] = None, cell_id: Optional[str] = None) -> Optional[str]:
         """Execute code in the kernel with optional user_expressions for namespace capture."""
         if not self.kernel_client:
             self.send_message({
@@ -215,12 +225,14 @@ class KernelBridge:
             msg_id = self.kernel_client.execute(code, user_expressions=user_expressions or {})
             self.pending_executions[msg_id] = {
                 "cell_idx": cell_idx,
+                "cell_id": cell_id,
                 "code": code,
                 "has_user_expressions": bool(user_expressions)
             }
             self.send_message({
                 "type": "execute_request",
                 "cell_idx": cell_idx,
+                "cell_id": cell_id,
                 "msg_id": msg_id
             })
 
@@ -348,17 +360,34 @@ class KernelBridge:
 
         try:
             msg_id = self.kernel_client.complete(code, cursor_pos)
-            # Completions come back on shell channel
-            reply = self.kernel_client.get_shell_msg(timeout=5)
-            if reply and reply.get("msg_type") == "complete_reply":
-                content = reply.get("content", {})
-                self.send_message({
-                    "type": "complete_reply",
-                    "matches": content.get("matches", []),
-                    "cursor_start": content.get("cursor_start", 0),
-                    "cursor_end": content.get("cursor_end", cursor_pos),
-                    "metadata": content.get("metadata", {})
-                })
+            # Completions come back on shell channel - wait for OUR reply
+            while True:
+                reply = self.kernel_client.get_shell_msg(timeout=5)
+                if not reply:
+                    break
+                parent_msg_id = reply.get("parent_header", {}).get("msg_id")
+                if parent_msg_id != msg_id:
+                    # Not our reply, keep waiting
+                    continue
+                if reply.get("msg_type") == "complete_reply":
+                    content = reply.get("content", {})
+                    self.send_message({
+                        "type": "complete_reply",
+                        "matches": content.get("matches", []),
+                        "cursor_start": content.get("cursor_start", 0),
+                        "cursor_end": content.get("cursor_end", cursor_pos),
+                        "metadata": content.get("metadata", {})
+                    })
+                    return
+                break
+            # No valid reply found
+            self.send_message({
+                "type": "complete_reply",
+                "matches": [],
+                "cursor_start": 0,
+                "cursor_end": cursor_pos,
+                "metadata": {}
+            })
         except Exception as e:
             self.send_message({
                 "type": "error",
@@ -460,8 +489,9 @@ def main():
             elif action == "execute":
                 code = cmd.get("code", "")
                 cell_idx = cmd.get("cell_idx", 0)
+                cell_id = cmd.get("cell_id")
                 user_expressions = cmd.get("user_expressions")
-                bridge.execute(code, cell_idx, user_expressions)
+                bridge.execute(code, cell_idx, user_expressions, cell_id=cell_id)
 
             elif action == "interrupt":
                 bridge.interrupt()


### PR DESCRIPTION
- Fix stream output dropping blank lines (output.lua)
- Fix execution output routed to wrong cell by using cell_id instead of positional index (kernel.lua, kernel_bridge.py)
- Fix edit float never re-opening after gd navigation by capturing was_in_edit before close (navigation.lua)
- Fix shell message routing for completion requests (kernel_bridge.py)
- Add debounced shadow file writes to reduce disk I/O during editing (shadow.lua, format.lua, init.lua)
- Fix pending_executions memory leak on kernel idle (kernel_bridge.py)
- Add resilience for _changetracking API changes across Neovim versions (edit.lua)