### PR TITLE
fix: stream output rendering, cell-id execution routing, shadow write debouncing, and edit-float viewport fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,15 @@ The parser should auto-compile on first load. If it fails:
 Ensure you have a language server installed for the notebook's language.
 Check `:LspInfo` while in the notebook to see attached clients.
 
+**Python imports unresolved in diagnostics, but code executes**
+
+If you see diagnostics like `Import "numpy" could not be resolved` while notebook execution works:
+
+- LSP and Jupyter kernel are separate processes and may use different Python environments
+- Check kernel Python: run `import sys; print(sys.executable)` in a cell
+- Configure your Python LSP (`pyright`/`basedpyright`) to use the same interpreter (for example, project `.venv`)
+- For notebooks, consider `shadow.location = "workspace"` so LSP runs with project context instead of temp paths
+
 **Kernel won't start**
 
 Check `:NotebookKernelStatus` for the Python path being used.
@@ -383,6 +392,13 @@ For non-Python kernels, ensure the kernel is installed (e.g., IJulia, IRkernel).
 **Images not showing**
 
 Requires snacks.nvim and a terminal which fully supports the kitty graphics protocol (kitty, Ghostty). For tmux, set `allow-passthrough=on`.
+
+**`[Image failed to load]` even when terminal support is true**
+
+If `:lua print(require("snacks").image.supports_terminal())` returns `true` but images still fail:
+
+- Run `:checkhealth snacks` (not just `:checkhealth ipynb`)
+- Ensure ImageMagick tools are installed (`magick`/`convert`) for non-PNG conversion
 
 ## 🗺️ Roadmap
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ The plugin reads the language from notebook metadata and automatically configure
 - **Syntax highlighting** via tree-sitter language injection
 - **LSP** by setting the shadow buffer's filetype (triggers your LSP config)
 - **Kernel execution** via `jupyter_client` (supports any installed Jupyter kernel)
+- **Blocking `input()` support** via floating prompt UI (`getpass` uses secure masked fallback)
 
 The default language when creating a new notebook is Python. You can specify a kernel when creating:
 
@@ -389,6 +390,11 @@ Check `:NotebookKernelStatus` for the Python path being used.
 Ensure `jupyter_client` is installed: `pip install jupyter_client`
 For non-Python kernels, ensure the kernel is installed (e.g., IJulia, IRkernel).
 
+**`input()` appears stuck**
+
+The kernel is waiting for stdin. Enter text in the floating prompt and press `<CR>`.
+Press `<Esc>` / `<C-c>` to cancel (the plugin interrupts the kernel).
+
 **Images not showing**
 
 Requires snacks.nvim and a terminal which fully supports the kitty graphics protocol (kitty, Ghostty). For tmux, set `allow-passthrough=on`.
@@ -407,6 +413,7 @@ If `:lua print(require("snacks").image.supports_terminal())` returns `true` but 
 - [x] Read/write .ipynb files
 - [x] Cell navigation and editing
 - [x] Kernel execution and output capture
+- [x] Blocking stdin input prompts (`input()` / `getpass`)
 - [x] Inline image rendering
 - [x] Variable inspector (Jupyter inspect protocol, auto-hover)
 - [x] Partial LSP support (diagnostics, completion, hover, definition, references, rename, formatting, document symbols, signature help, document highlight, inlay hints)

--- a/doc/ipynb.txt
+++ b/doc/ipynb.txt
@@ -22,6 +22,7 @@ Features:
 - Partial language server support (completion, diagnostics, go-to-definition,
   references, rename, formatting) - most keymaps work but plugin compatibility varies
 - Jupyter kernel integration for code execution
+- Blocking stdin prompts (`input()`), with secure fallback for password prompts
 - Variable inspector using Jupyter inspect protocol (with auto-hover)
 - Multi-language support (Python, Julia, R, etc.)
 - Inline image rendering (requires snacks.nvim)
@@ -509,6 +510,12 @@ Kernel won't start ~
     Check `:NotebookKernelStatus` for the Python path being used.
     Ensure `jupyter_client` is installed: `pip install jupyter_client`
     For non-Python kernels, ensure the kernel is installed (e.g., IJulia, IRkernel).
+
+`input()` appears stuck ~
+
+    The kernel is waiting for stdin input.
+    Enter text in the floating prompt and press <CR>.
+    Press <Esc> or <C-c> to cancel (interrupts the kernel).
 
 Images not showing ~
 

--- a/lua/ipynb/config.lua
+++ b/lua/ipynb/config.lua
@@ -12,6 +12,7 @@ local M = {}
 ---@field inspector InspectorConfig
 ---@field folding FoldingConfig
 ---@field format FormatConfig
+---@field shadow ShadowConfig
 
 ---@class FloatConfig
 ---@field width number Window width as fraction of screen (0-1) - used for centered mode
@@ -67,6 +68,7 @@ local M = {}
 ---@class ShadowConfig
 ---@field location "temp"|"workspace" Location for shadow file (default: "temp")
 ---@field dir string Directory name used when location="workspace" (default: ".ipynb.nvim")
+---@field debounce_ms number Debounce delay for shadow file disk writes (default: 400)
 
 ---@class HighlightConfig Highlight groups to link to (use existing groups or define your own)
 ---@field border string Cell border color (default: 'Comment')
@@ -190,15 +192,16 @@ M.defaults = {
 	folding = {
 		hide_output = false, -- Include end marker in fold to hide output when folded
 	},
-	format = {
-		enabled = true, -- Wrap vim.lsp.buf.format() to work with notebooks
-		trailing_blank_lines = 0, -- Max trailing blank lines to keep after formatting
-	},
-	shadow = {
-		location = "temp", -- "temp" (default) or "workspace"
-		dir = ".ipynb.nvim",
-	},
-}
+		format = {
+			enabled = true, -- Wrap vim.lsp.buf.format() to work with notebooks
+			trailing_blank_lines = 0, -- Max trailing blank lines to keep after formatting
+		},
+		shadow = {
+			location = "temp", -- "temp" (default) or "workspace"
+			dir = ".ipynb.nvim",
+			debounce_ms = 400,
+		},
+	}
 
 -- Current configuration (populated by setup)
 ---@type NotebookConfig

--- a/lua/ipynb/edit.lua
+++ b/lua/ipynb/edit.lua
@@ -93,6 +93,10 @@ local function update_edit_window_height(edit, line_count)
     vim.api.nvim_win_call(edit.win, function()
       local view = vim.fn.winsaveview()
       vim.api.nvim_win_set_height(edit.win, math.max(line_count, 1))
+      -- Edit floats are sized to full cell content, so keep viewport anchored
+      -- to the first line. This avoids "o" from clipping the previous line
+      -- when a 1-line float grows and Neovim had scrolled topline to 2.
+      view.topline = 1
       vim.fn.winrestview(view)
     end)
   end

--- a/lua/ipynb/edit.lua
+++ b/lua/ipynb/edit.lua
@@ -106,16 +106,69 @@ end
 ---@param cell Cell
 ---@param lines string[]
 ---@return number buf
+local function replace_buf_lines(buf, lines)
+  local was_modifiable = vim.bo[buf].modifiable
+  if not was_modifiable then
+    vim.bo[buf].modifiable = true
+  end
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.bo[buf].modified = false
+  if not was_modifiable then
+    vim.bo[buf].modifiable = false
+  end
+end
+
+---@param name string
+---@return number|nil
+local function find_buffer_by_name(name)
+  for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_valid(buf) and vim.api.nvim_buf_get_name(buf) == name then
+      return buf
+    end
+  end
+  return nil
+end
+
 local function get_or_create_edit_buf(cell, lines)
   -- Reuse existing buffer if valid (preserves undo history)
   if cell.edit_buf and vim.api.nvim_buf_is_valid(cell.edit_buf) then
     -- Refresh content from facade (may have changed via undo/redo)
     local current = vim.api.nvim_buf_get_lines(cell.edit_buf, 0, -1, false)
     if table.concat(current, '\n') ~= table.concat(lines, '\n') then
-      vim.api.nvim_buf_set_lines(cell.edit_buf, 0, -1, false, lines)
-      vim.bo[cell.edit_buf].modified = false
+      replace_buf_lines(cell.edit_buf, lines)
     end
     return cell.edit_buf
+  end
+
+  -- Resolve language and intended buffer name before creating a new buffer.
+  local state = require('ipynb.state').get()
+  local lang = 'python' -- default
+  if cell.type == 'code' then
+    if state and state.facade_buf then
+      lang = vim.b[state.facade_buf].ipynb_language or 'python'
+    end
+  else
+    lang = 'markdown'
+  end
+  local notebook_name = state and state.source_path and vim.fn.fnamemodify(state.source_path, ':t') or 'notebook'
+  local buffer_name = string.format('[%s:%s]', notebook_name, cell.id or 'cell')
+
+  -- Reuse hidden buffer with the same name (common after reload/reopen) to avoid E95.
+  local existing = find_buffer_by_name(buffer_name)
+  if existing and vim.api.nvim_buf_is_valid(existing) then
+    M.register_edit_buffer(existing)
+    vim.bo[existing].bufhidden = 'hide'
+    vim.bo[existing].buftype = 'acwrite'
+    vim.bo[existing].swapfile = false
+    vim.bo[existing].filetype = lang
+    pcall(vim.treesitter.start, existing, lang)
+    vim.b[existing].ipynb_edit_lang = lang
+    local current = vim.api.nvim_buf_get_lines(existing, 0, -1, false)
+    if table.concat(current, '\n') ~= table.concat(lines, '\n') then
+      replace_buf_lines(existing, lines)
+    end
+    cell.edit_buf = existing
+    return existing
   end
 
   -- Create new buffer (unlisted, not scratch - we'll set buftype manually)
@@ -124,20 +177,12 @@ local function get_or_create_edit_buf(cell, lines)
   -- Register as edit buffer to suppress change tracking errors
   M.register_edit_buffer(buf)
 
-  -- Use language from notebook metadata for code cells (stored in facade buffer variable)
-  local lang = 'python' -- default
-  local state = require('ipynb.state').get()
-  if cell.type == 'code' then
-    if state and state.facade_buf then
-      lang = vim.b[state.facade_buf].ipynb_language or 'python'
-    end
-  else
-    lang = 'markdown'
-  end
-
   -- Give buffer a name (required for :w to work with acwrite)
-  local notebook_name = state and state.source_path and vim.fn.fnamemodify(state.source_path, ':t') or 'notebook'
-  vim.api.nvim_buf_set_name(buf, string.format('[%s:%s]', notebook_name, cell.id or 'cell'))
+  local ok_named = pcall(vim.api.nvim_buf_set_name, buf, buffer_name)
+  if not ok_named then
+    -- Last-resort suffix avoids hard failure if another buffer races this name.
+    vim.api.nvim_buf_set_name(buf, string.format('%s#%d', buffer_name, buf))
+  end
 
   vim.bo[buf].bufhidden = 'hide' -- Keep buffer when window closes
   -- Use 'acwrite' so :w triggers BufWriteCmd instead of E382 error
@@ -172,8 +217,7 @@ local function get_or_create_edit_buf(cell, lines)
 
   -- Enable undo in edit buffers for natural undo behavior while typing
   -- Facade undo syncs at natural break points (InsertLeave, etc.)
-  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-  vim.bo[buf].modified = false
+  replace_buf_lines(buf, lines)
 
   -- Store in cell for reuse
   cell.edit_buf = buf

--- a/lua/ipynb/images.lua
+++ b/lua/ipynb/images.lua
@@ -329,12 +329,17 @@ function M.get_image_virt_lines(state, cell, output, image_index)
 	-- Write to cache file
 	local cache_dir = get_cache_dir()
 	local ext = MIME_EXTENSIONS[mime] or "png"
-	local filename = string.format("%s-%d.%s", cell_id, image_index, ext)
+	local data_hash = vim.fn.sha256(image_data):sub(1, 12)
+	local filename = string.format("%s-%d-%s.%s", cell_id, image_index, data_hash, ext)
 	local path = cache_dir .. "/" .. filename
 
 	if not write_binary_file(path, file_content) then
 		return nil, 0
 	end
+
+	-- File content may have changed between executions for the same cell/image index.
+	-- Drop cached object so snacks reloads fresh bytes from disk.
+	image_cache[path] = nil
 
 	-- Get or create snacks Image (handles sending image data to terminal)
 	local img = get_or_create_image(path)
@@ -456,6 +461,10 @@ function M.clear_images(state, cell_id)
 	local ok, Snacks = pcall(require, "snacks")
 	if ok and Snacks.image and Snacks.image.terminal then
 		for _, entry in ipairs(state.images[cell_id]) do
+			if entry.path then
+				image_cache[entry.path] = nil
+				pcall(vim.fn.delete, entry.path)
+			end
 			if entry.img and entry.placement_id then
 				pcall(Snacks.image.terminal.request, {
 					a = "d",

--- a/lua/ipynb/input.lua
+++ b/lua/ipynb/input.lua
@@ -2,6 +2,14 @@
 
 local M = {}
 
+local function leave_insert_mode()
+  local mode = vim.api.nvim_get_mode().mode
+  local head = mode:sub(1, 1)
+  if head == "i" or head == "R" then
+    pcall(vim.cmd, "stopinsert")
+  end
+end
+
 ---@param prompt string|nil
 ---@return string
 local function normalize_prompt(prompt)
@@ -19,6 +27,8 @@ local function close_state_prompt(state)
   if not state or not state._input_state then
     return
   end
+
+  leave_insert_mode()
 
   local prompt_state = state._input_state
   state._input_state = nil

--- a/lua/ipynb/input.lua
+++ b/lua/ipynb/input.lua
@@ -1,0 +1,154 @@
+-- ipynb/input.lua - Kernel stdin input UI
+
+local M = {}
+
+---@param prompt string|nil
+---@return string
+local function normalize_prompt(prompt)
+  local p = prompt or "Input: "
+  p = p:gsub("\r", "")
+  p = p:gsub("\n", " ")
+  if p == "" then
+    p = "Input: "
+  end
+  return p
+end
+
+---@param state NotebookState
+local function close_state_prompt(state)
+  if not state or not state._input_state then
+    return
+  end
+
+  local prompt_state = state._input_state
+  state._input_state = nil
+
+  if prompt_state.win and vim.api.nvim_win_is_valid(prompt_state.win) then
+    pcall(vim.api.nvim_win_close, prompt_state.win, true)
+  end
+  if prompt_state.buf and vim.api.nvim_buf_is_valid(prompt_state.buf) then
+    pcall(vim.api.nvim_buf_delete, prompt_state.buf, { force = true })
+  end
+
+  if prompt_state.parent_win and vim.api.nvim_win_is_valid(prompt_state.parent_win) then
+    pcall(vim.api.nvim_set_current_win, prompt_state.parent_win)
+  end
+end
+
+---Close the currently active kernel input prompt, if any.
+---@param state NotebookState
+function M.close(state)
+  close_state_prompt(state)
+end
+
+---Open a prompt for kernel stdin input.
+---@param state NotebookState
+---@param request table { request_id: string, prompt: string|nil, password: boolean|nil }
+---@param on_submit fun(value: string)
+---@param on_cancel fun()|nil
+function M.request(state, request, on_submit, on_cancel)
+  close_state_prompt(state)
+
+  local prompt = normalize_prompt(request and request.prompt or nil)
+  local is_password = request and request.password == true
+
+  if is_password then
+    local ok, value = pcall(vim.fn.inputsecret, prompt)
+    if ok then
+      on_submit(value or "")
+    else
+      if on_cancel then
+        on_cancel()
+      end
+    end
+    return
+  end
+
+  local parent_win = vim.api.nvim_get_current_win()
+  local buf = vim.api.nvim_create_buf(false, true)
+
+  vim.bo[buf].buftype = "nofile"
+  vim.bo[buf].bufhidden = "wipe"
+  vim.bo[buf].swapfile = false
+  vim.bo[buf].modifiable = true
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "" })
+
+  local min_width = 24
+  local max_width = math.max(min_width, math.floor(vim.o.columns * 0.65))
+  local prompt_width = vim.fn.strdisplaywidth(prompt)
+  local width = math.max(min_width, math.min(max_width, prompt_width + 8))
+  local row = math.max(0, math.floor((vim.o.lines - 1) / 2) - 1)
+  local col = math.max(0, math.floor((vim.o.columns - width) / 2))
+
+  local win = vim.api.nvim_open_win(buf, true, {
+    relative = "editor",
+    row = row,
+    col = col,
+    width = width,
+    height = 1,
+    style = "minimal",
+    border = "rounded",
+    title = " " .. prompt .. " ",
+    title_pos = "left",
+    zindex = 45,
+  })
+
+  vim.wo[win].number = false
+  vim.wo[win].relativenumber = false
+  vim.wo[win].signcolumn = "no"
+  vim.wo[win].wrap = false
+  vim.wo[win].cursorline = false
+
+  state._input_state = {
+    buf = buf,
+    win = win,
+    parent_win = parent_win,
+    request_id = request and request.request_id or nil,
+  }
+
+  local done = false
+
+  local function finish_cancel()
+    if done then
+      return
+    end
+    done = true
+    close_state_prompt(state)
+    if on_cancel then
+      on_cancel()
+    end
+  end
+
+  local function finish_submit()
+    if done then
+      return
+    end
+    done = true
+    local line = ""
+    if vim.api.nvim_buf_is_valid(buf) then
+      line = vim.api.nvim_buf_get_lines(buf, 0, 1, false)[1] or ""
+    end
+    close_state_prompt(state)
+    on_submit(line)
+  end
+
+  local group = vim.api.nvim_create_augroup("IpynbInput_" .. tostring(buf), { clear = true })
+  vim.api.nvim_create_autocmd("WinClosed", {
+    group = group,
+    callback = function(ev)
+      if tonumber(ev.match) == win then
+        finish_cancel()
+      end
+    end,
+  })
+
+  local opts = { buffer = buf, silent = true, nowait = true }
+  vim.keymap.set({ "n", "i" }, "<CR>", finish_submit, opts)
+  vim.keymap.set({ "n", "i" }, "<C-c>", finish_cancel, opts)
+  vim.keymap.set({ "n", "i" }, "<Esc>", finish_cancel, opts)
+  vim.keymap.set("n", "q", finish_cancel, opts)
+
+  vim.cmd("startinsert")
+end
+
+return M

--- a/lua/ipynb/kernel.lua
+++ b/lua/ipynb/kernel.lua
@@ -9,7 +9,7 @@ local M = {}
 ---@field kernel_id string|nil Kernel ID
 ---@field kernel_name string Kernel name (e.g., "python3")
 ---@field execution_state string Current state: "idle", "busy", "starting"
----@field pending_cells table<string, {cell_idx: number}> Cells waiting for execution
+---@field pending_cells table<string, {cell_id: string}> Cells waiting for execution
 ---@field callbacks table Async operation callbacks
 
 ---Create a new kernel state for a notebook
@@ -65,6 +65,25 @@ local function update_cell_field(state, cell_idx, field, value)
       require("ipynb.visuals").render_all(state)
     end
   end)
+end
+
+---Resolve a kernel message target to the current cell index by stable cell_id.
+---@param state NotebookState
+---@param msg table
+---@return number|nil cell_idx, Cell|nil cell
+local function resolve_message_cell(state, msg)
+  if msg.cell_id and type(msg.cell_id) == "string" then
+    for i, cell in ipairs(state.cells or {}) do
+      if cell.id == msg.cell_id then
+        return i, cell
+      end
+    end
+    -- Message was keyed by cell_id but target no longer exists (e.g. deleted).
+    -- Drop the message to avoid misrouting output to the wrong cell.
+    return nil, nil
+  end
+
+  return nil, nil
 end
 
 ---Set the notebook language (updates metadata, treesitter, and LSP)
@@ -161,26 +180,31 @@ local function handle_message(state, msg)
 
   elseif msg_type == "status" then
     kernel.execution_state = msg.state or "idle"
-    if msg.cell_idx and type(msg.cell_idx) == "number" then
-      update_cell_field(state, msg.cell_idx, "execution_state", msg.state)
-      if msg.state == "idle" then
-        kernel.pending_cells[msg.cell_idx] = nil
+    local target_idx = resolve_message_cell(state, msg)
+    if target_idx then
+      update_cell_field(state, target_idx, "execution_state", msg.state)
+    end
+    if msg.state == "idle" then
+      if msg.cell_id and type(msg.cell_id) == "string" then
+        kernel.pending_cells[msg.cell_id] = nil
       end
     end
 
   elseif msg_type == "execute_input" then
-    if msg.cell_idx and msg.execution_count then
-      update_cell_field(state, msg.cell_idx, "execution_count", msg.execution_count)
+    local target_idx = resolve_message_cell(state, msg)
+    if target_idx and msg.execution_count then
+      update_cell_field(state, target_idx, "execution_count", msg.execution_count)
     end
 
   elseif msg_type == "output" then
-    if msg.cell_idx and msg.output then
+    local target_idx, target_cell = resolve_message_cell(state, msg)
+    if target_idx and target_cell and msg.output then
       vim.schedule(function()
-        if state.cells and state.cells[msg.cell_idx] then
-          local cell = state.cells[msg.cell_idx]
-          cell.outputs = cell.outputs or {}
-          table.insert(cell.outputs, msg.output)
-          require("ipynb.output").render_outputs(state, msg.cell_idx)
+        local current_cell = state.cells and state.cells[target_idx] or nil
+        if current_cell and target_cell.id == current_cell.id then
+          current_cell.outputs = current_cell.outputs or {}
+          table.insert(current_cell.outputs, msg.output)
+          require("ipynb.output").render_outputs(state, target_idx)
         end
       end)
     end
@@ -489,17 +513,27 @@ function M.execute(state, cell_idx)
     return false
   end
 
+  -- Ensure the cell has a stable ID before execution routing.
+  if not cell.id or cell.id == "" then
+    local state_mod = require("ipynb.state")
+    local id = state_mod.generate_cell_id(state.cell_ids)
+    state.cell_ids[id] = true
+    cell.id = id
+  end
+
   require("ipynb.output").clear_outputs(state, cell_idx)
 
   cell.execution_state = "busy"
-  state.kernel.pending_cells[cell_idx] = { cell_idx = cell_idx }
+  state.kernel.pending_cells[cell.id] = {
+    cell_id = cell.id,
+  }
 
   require("ipynb.visuals").render_all(state)
 
   return send_command(state, {
     action = "execute",
     code = cell.source,
-    cell_idx = cell_idx,
+    cell_id = cell.id,
   })
 end
 

--- a/lua/ipynb/kernel.lua
+++ b/lua/ipynb/kernel.lua
@@ -10,6 +10,7 @@ local M = {}
 ---@field kernel_name string Kernel name (e.g., "python3")
 ---@field execution_state string Current state: "idle", "busy", "starting"
 ---@field pending_cells table<string, {cell_id: string}> Cells waiting for execution
+---@field cell_index_by_id table<string, number> Cached cell_id -> index map
 ---@field callbacks table Async operation callbacks
 
 ---Create a new kernel state for a notebook
@@ -22,6 +23,7 @@ local function create_kernel_state()
     kernel_name = "python3",
     execution_state = "idle",
     pending_cells = {},
+    cell_index_by_id = {},
     callbacks = {
       complete = nil,
       inspect = {},
@@ -67,17 +69,47 @@ local function update_cell_field(state, cell_idx, field, value)
   end)
 end
 
+---Rebuild the cell_id -> index cache for fast kernel message routing.
+---@param state NotebookState
+local function rebuild_cell_index_map(state)
+  if not state.kernel then
+    return
+  end
+  local map = {}
+  for i, cell in ipairs(state.cells or {}) do
+    if cell.id and type(cell.id) == "string" then
+      map[cell.id] = i
+    end
+  end
+  state.kernel.cell_index_by_id = map
+end
+
 ---Resolve a kernel message target to the current cell index by stable cell_id.
 ---@param state NotebookState
 ---@param msg table
 ---@return number|nil cell_idx, Cell|nil cell
 local function resolve_message_cell(state, msg)
   if msg.cell_id and type(msg.cell_id) == "string" then
-    for i, cell in ipairs(state.cells or {}) do
-      if cell.id == msg.cell_id then
-        return i, cell
+    local map = state.kernel and state.kernel.cell_index_by_id or nil
+    local idx = map and map[msg.cell_id] or nil
+    if idx then
+      local cell = state.cells and state.cells[idx] or nil
+      if cell and cell.id == msg.cell_id then
+        return idx, cell
       end
     end
+
+    -- Cache may be stale after insert/delete/move/undo; rebuild and retry once.
+    rebuild_cell_index_map(state)
+    map = state.kernel and state.kernel.cell_index_by_id or nil
+    idx = map and map[msg.cell_id] or nil
+    if idx then
+      local cell = state.cells and state.cells[idx] or nil
+      if cell and cell.id == msg.cell_id then
+        return idx, cell
+      end
+    end
+
     -- Message was keyed by cell_id but target no longer exists (e.g. deleted).
     -- Drop the message to avoid misrouting output to the wrong cell.
     return nil, nil
@@ -519,6 +551,9 @@ function M.execute(state, cell_idx)
     local id = state_mod.generate_cell_id(state.cell_ids)
     state.cell_ids[id] = true
     cell.id = id
+    if state.kernel and state.kernel.cell_index_by_id then
+      state.kernel.cell_index_by_id[id] = cell_idx
+    end
   end
 
   require("ipynb.output").clear_outputs(state, cell_idx)

--- a/lua/ipynb/kernel.lua
+++ b/lua/ipynb/kernel.lua
@@ -55,6 +55,28 @@ local function send_command(state, cmd)
   return true
 end
 
+---Send an input reply to the Python bridge.
+---@param state NotebookState
+---@param request_id string
+---@param value string
+---@return boolean success
+local function send_input_reply(state, request_id, value)
+  return send_command(state, {
+    action = "input_reply",
+    request_id = request_id,
+    value = value,
+  })
+end
+
+---Close any active notebook input prompt.
+---@param state NotebookState
+local function close_input_prompt(state)
+  local ok, input_mod = pcall(require, "ipynb.input")
+  if ok then
+    input_mod.close(state)
+  end
+end
+
 ---Update a cell field and re-render visuals
 ---@param state NotebookState
 ---@param cell_idx number
@@ -217,10 +239,33 @@ local function handle_message(state, msg)
       update_cell_field(state, target_idx, "execution_state", msg.state)
     end
     if msg.state == "idle" then
+      close_input_prompt(state)
       if msg.cell_id and type(msg.cell_id) == "string" then
         kernel.pending_cells[msg.cell_id] = nil
       end
     end
+
+  elseif msg_type == "input_request" then
+    if type(msg.request_id) ~= "string" or msg.request_id == "" then
+      vim.schedule(function()
+        vim.notify("Kernel input request missing request_id", vim.log.levels.ERROR)
+      end)
+      return
+    end
+
+    vim.schedule(function()
+      local input_mod = require("ipynb.input")
+      input_mod.request(
+        state,
+        msg,
+        function(value)
+          send_input_reply(state, msg.request_id, value or "")
+        end,
+        function()
+          send_command(state, { action = "interrupt" })
+        end
+      )
+    end)
 
   elseif msg_type == "execute_input" then
     local target_idx = resolve_message_cell(state, msg)
@@ -244,6 +289,7 @@ local function handle_message(state, msg)
   elseif msg_type == "interrupted" then
     kernel.execution_state = "idle"
     kernel.pending_cells = {}
+    close_input_prompt(state)
     vim.schedule(function()
       vim.notify("Kernel interrupted", vim.log.levels.INFO)
     end)
@@ -251,6 +297,7 @@ local function handle_message(state, msg)
   elseif msg_type == "restarted" then
     kernel.execution_state = "idle"
     kernel.pending_cells = {}
+    close_input_prompt(state)
     vim.schedule(function()
       vim.notify("Kernel restarted", vim.log.levels.INFO)
     end)
@@ -259,6 +306,7 @@ local function handle_message(state, msg)
     kernel.connected = false
     kernel.execution_state = "idle"
     kernel.pending_cells = {}
+    close_input_prompt(state)
 
   elseif msg_type == "error" then
     vim.schedule(function()

--- a/lua/ipynb/lsp/format.lua
+++ b/lua/ipynb/lsp/format.lua
@@ -126,6 +126,7 @@ local function handle_range_format(ctx, method, params, handler, client, _req_bu
   end
 
   local cells_mod = require('ipynb.cells')
+  local shadow = require('ipynb.lsp.shadow')
 
   -- Edit buffer: range is always within single cell (the one being edited)
   if ctx.is_edit_buf and state.edit_state then
@@ -185,6 +186,7 @@ local function handle_range_format(ctx, method, params, handler, client, _req_bu
 
     -- Make the request to shadow buffer through the original client.request
     local orig_request = rawget(client, '_orig_request') or client.request
+    shadow.flush_shadow_write(state)
     return true, select(2, orig_request(client, method, rewritten_params, wrapped_handler, state.shadow_buf))
   end
 
@@ -252,6 +254,7 @@ local function handle_range_format(ctx, method, params, handler, client, _req_bu
   end
 
   local orig_request = rawget(client, '_orig_request') or client.request
+  shadow.flush_shadow_write(state)
   return true, select(2, orig_request(client, method, rewritten_params, wrapped_handler, state.shadow_buf))
 end
 
@@ -299,6 +302,9 @@ function M.format_cell(state, cell_idx, callback)
     if callback then callback() end
     return
   end
+
+  -- Ensure on-disk shadow file is up to date for servers that read from URI path.
+  shadow.flush_shadow_write(state)
 
   -- Build formatting request params
   local params = {

--- a/lua/ipynb/lsp/init.lua
+++ b/lua/ipynb/lsp/init.lua
@@ -31,6 +31,8 @@ M.create_shadow = shadow.create_shadow
 M.attach_lsp = shadow.attach_lsp
 M.refresh_shadow = shadow.refresh_shadow
 M.sync_shadow_region = shadow.sync_shadow_region
+M.schedule_shadow_write = shadow.schedule_shadow_write
+M.flush_shadow_write = shadow.flush_shadow_write
 
 -- Re-export diagnostics functions
 M.setup_diagnostics_proxy = diagnostics.setup_diagnostics_proxy

--- a/lua/ipynb/lsp/shadow.lua
+++ b/lua/ipynb/lsp/shadow.lua
@@ -4,6 +4,51 @@
 
 local M = {}
 
+---Get configured shadow-write debounce delay in ms
+---@return number
+local function get_shadow_debounce_ms()
+  local cfg = require('ipynb.config').get()
+  local shadow_cfg = (cfg and cfg.shadow) or {}
+  local delay = tonumber(shadow_cfg.debounce_ms) or 400
+  if delay < 0 then
+    delay = 0
+  end
+  return math.floor(delay)
+end
+
+---Write current shadow buffer content to disk
+---@param state NotebookState
+---@return boolean
+local function write_shadow_to_disk(state)
+  if not state.shadow_path then
+    state._shadow_write_pending = false
+    return false
+  end
+  if not state.shadow_buf or not vim.api.nvim_buf_is_valid(state.shadow_buf) then
+    state._shadow_write_pending = false
+    return false
+  end
+
+  local lines = vim.api.nvim_buf_get_lines(state.shadow_buf, 0, -1, false)
+  local ok = pcall(vim.fn.writefile, lines, state.shadow_path)
+  state._shadow_write_pending = false
+  if ok then
+    vim.bo[state.shadow_buf].modified = false
+  end
+  return ok
+end
+
+---Stop a pending shadow-write timer without closing it
+---@param state NotebookState
+local function stop_shadow_write_timer(state)
+  if not state then
+    return
+  end
+  if state._shadow_write_timer then
+    pcall(state._shadow_write_timer.stop, state._shadow_write_timer)
+  end
+end
+
 ---Get language info from notebook metadata
 ---@param state NotebookState
 ---@return string language (e.g., "python", "julia", "r")
@@ -114,6 +159,7 @@ function M.create_shadow(state)
 
   -- Write to disk for LSP
   vim.fn.writefile(shadow_lines, shadow_path)
+  state._shadow_write_pending = false
 
   -- Configure for LSP (don't set buftype - need it to be normal for LSP to attach)
   vim.bo[shadow_buf].filetype = lang
@@ -207,11 +253,81 @@ function M.refresh_shadow(state)
   local shadow_lines = M.generate_shadow_lines(state)
   vim.api.nvim_buf_set_lines(state.shadow_buf, 0, -1, false, shadow_lines)
 
+  -- Cancel pending debounced write before full refresh write.
+  stop_shadow_write_timer(state)
+
   -- Update temp file for LSP
   vim.fn.writefile(shadow_lines, state.shadow_path)
+  state._shadow_write_pending = false
 
   -- Clear modified to prevent save warnings
   vim.bo[state.shadow_buf].modified = false
+end
+
+---Schedule writing the shadow buffer to disk after a debounce delay.
+---@param state NotebookState
+---@param delay_ms number|nil
+function M.schedule_shadow_write(state, delay_ms)
+  if not state.shadow_path then
+    return
+  end
+  if not state.shadow_buf or not vim.api.nvim_buf_is_valid(state.shadow_buf) then
+    return
+  end
+
+  state._shadow_write_pending = true
+  delay_ms = delay_ms or get_shadow_debounce_ms()
+  if delay_ms <= 0 then
+    write_shadow_to_disk(state)
+    return
+  end
+
+  local timer = state._shadow_write_timer
+  if not timer then
+    timer = vim.uv.new_timer()
+    if not timer then
+      write_shadow_to_disk(state)
+      return
+    end
+    state._shadow_write_timer = timer
+  end
+
+  stop_shadow_write_timer(state)
+  local ok = pcall(timer.start, timer, delay_ms, 0, vim.schedule_wrap(function()
+    if state._shadow_write_timer ~= timer then
+      return
+    end
+    write_shadow_to_disk(state)
+  end))
+  if not ok then
+    write_shadow_to_disk(state)
+  end
+end
+
+---Force a pending shadow write to disk immediately.
+---@param state NotebookState
+function M.flush_shadow_write(state)
+  if not state then
+    return
+  end
+  stop_shadow_write_timer(state)
+  if state._shadow_write_pending then
+    write_shadow_to_disk(state)
+  end
+end
+
+---Cleanup shadow-write timer for a notebook state.
+---@param state NotebookState
+function M.cleanup_shadow_write(state)
+  if not state then
+    return
+  end
+  stop_shadow_write_timer(state)
+  if state._shadow_write_timer then
+    pcall(state._shadow_write_timer.close, state._shadow_write_timer)
+    state._shadow_write_timer = nil
+  end
+  state._shadow_write_pending = false
 end
 
 ---Sync a region of the shadow buffer after an edit
@@ -239,9 +355,8 @@ function M.sync_shadow_region(state, start_line, old_end_line, new_lines, cell_t
 
   vim.api.nvim_buf_set_lines(state.shadow_buf, start_line, old_end_line, false, shadow_lines)
 
-  -- Update temp file for LSP
-  local all_lines = vim.api.nvim_buf_get_lines(state.shadow_buf, 0, -1, false)
-  vim.fn.writefile(all_lines, state.shadow_path)
+  -- Debounce disk writes; LSP still sees immediate in-memory buffer changes.
+  M.schedule_shadow_write(state)
 
   -- Clear modified to prevent save warnings
   vim.bo[state.shadow_buf].modified = false

--- a/lua/ipynb/output.lua
+++ b/lua/ipynb/output.lua
@@ -19,7 +19,7 @@ end
 ---@param lines table[] Virtual lines array to append to
 ---@param text_plain string|table The text/plain data
 ---@param prefix string|nil Optional prefix for first line (e.g., "Out: ")
----@param hl string Highlight group
+---@param hl string|nil Highlight group
 local function add_text_plain_lines(lines, text_plain, prefix, hl)
   local text = to_string(text_plain)
 
@@ -48,10 +48,7 @@ function M.render_output(output)
   local images_mod = require('ipynb.images')
 
   if output.output_type == 'stream' then
-    local text = to_string(output.text)
-    for line in text:gmatch('[^\n]+') do
-      table.insert(lines, { { line, 'IpynbOutput' } })
-    end
+    add_text_plain_lines(lines, output.text, nil, 'IpynbOutput')
   elseif output.output_type == 'execute_result' then
     -- Check if this has image data
     local has_image = images_mod.get_image_data(output)
@@ -119,7 +116,13 @@ function M.build_output_text(cell)
   for _, output in ipairs(cell.outputs) do
     if output.output_type == 'stream' then
       local text = to_string(output.text)
-      for line in text:gmatch('[^\n]+') do
+
+      -- Match display behavior: trim one trailing newline but keep intentional blank lines
+      if text:sub(-1) == '\n' then
+        text = text:sub(1, -2)
+      end
+
+      for _, line in ipairs(vim.split(text, '\n', { plain = true })) do
         table.insert(lines, line)
       end
     elseif output.output_type == 'execute_result' then

--- a/lua/ipynb/state.lua
+++ b/lua/ipynb/state.lua
@@ -46,6 +46,8 @@ local M = {}
 ---@field facade_path string Original .ipynb file path (same as source_path)
 ---@field shadow_buf number|nil Hidden buffer for LSP (code cells only)
 ---@field shadow_path string|nil Temp .py file path for shadow buffer
+---@field _shadow_write_timer uv_timer_t|nil Debounce timer for shadow file writes
+---@field _shadow_write_pending boolean|nil Whether a debounced shadow write is pending
 ---@field source_path string Original .ipynb path
 ---@field namespace number Extmark namespace
 ---@field edit_state EditState|nil
@@ -107,6 +109,8 @@ function M.create(source_path)
     facade_path = '',
     shadow_buf = nil,
     shadow_path = nil,
+    _shadow_write_timer = nil,
+    _shadow_write_pending = false,
     source_path = abs_path,
     namespace = vim.api.nvim_create_namespace('notebook_' .. abs_path),
     edit_state = nil,
@@ -201,6 +205,10 @@ function M.remove(buf)
     end
 
     -- Cleanup shadow buffer and temp file
+    local shadow_ok, shadow_mod = pcall(require, 'ipynb.lsp.shadow')
+    if shadow_ok then
+      shadow_mod.cleanup_shadow_write(state)
+    end
     if state.shadow_buf and vim.api.nvim_buf_is_valid(state.shadow_buf) then
       vim.api.nvim_buf_delete(state.shadow_buf, { force = true })
     end

--- a/lua/ipynb/state.lua
+++ b/lua/ipynb/state.lua
@@ -48,6 +48,7 @@ local M = {}
 ---@field shadow_path string|nil Temp .py file path for shadow buffer
 ---@field _shadow_write_timer uv_timer_t|nil Debounce timer for shadow file writes
 ---@field _shadow_write_pending boolean|nil Whether a debounced shadow write is pending
+---@field _input_state table|nil Active kernel stdin prompt state
 ---@field source_path string Original .ipynb path
 ---@field namespace number Extmark namespace
 ---@field edit_state EditState|nil
@@ -111,6 +112,7 @@ function M.create(source_path)
     shadow_path = nil,
     _shadow_write_timer = nil,
     _shadow_write_pending = false,
+    _input_state = nil,
     source_path = abs_path,
     namespace = vim.api.nvim_create_namespace('notebook_' .. abs_path),
     edit_state = nil,

--- a/python/kernel_bridge.py
+++ b/python/kernel_bridge.py
@@ -138,20 +138,23 @@ class KernelBridge:
 
         # Find the cell this message belongs to
         exec_info = self.pending_executions.get(msg_id, {})
-        cell_idx = exec_info.get("cell_idx")
+        cell_id = exec_info.get("cell_id")
 
         if msg_type == "status":
             execution_state = content.get("execution_state", "")
             self.send_message({
                 "type": "status",
                 "state": execution_state,
-                "cell_idx": cell_idx
+                "cell_id": cell_id
             })
+            if execution_state == "idle":
+                # Execution is complete, drop tracking to prevent unbounded growth.
+                self.pending_executions.pop(msg_id, None)
 
         elif msg_type == "stream":
             self.send_message({
                 "type": "output",
-                "cell_idx": cell_idx,
+                "cell_id": cell_id,
                 "output": {
                     "output_type": "stream",
                     "name": content.get("name", "stdout"),
@@ -162,7 +165,7 @@ class KernelBridge:
         elif msg_type == "execute_result":
             self.send_message({
                 "type": "output",
-                "cell_idx": cell_idx,
+                "cell_id": cell_id,
                 "output": {
                     "output_type": "execute_result",
                     "execution_count": content.get("execution_count"),
@@ -174,7 +177,7 @@ class KernelBridge:
         elif msg_type == "display_data":
             self.send_message({
                 "type": "output",
-                "cell_idx": cell_idx,
+                "cell_id": cell_id,
                 "output": {
                     "output_type": "display_data",
                     "data": content.get("data", {}),
@@ -185,7 +188,7 @@ class KernelBridge:
         elif msg_type == "error":
             self.send_message({
                 "type": "output",
-                "cell_idx": cell_idx,
+                "cell_id": cell_id,
                 "output": {
                     "output_type": "error",
                     "ename": content.get("ename", "Error"),
@@ -198,46 +201,52 @@ class KernelBridge:
             # Execution started
             self.send_message({
                 "type": "execute_input",
-                "cell_idx": cell_idx,
+                "cell_id": cell_id,
                 "execution_count": content.get("execution_count")
             })
 
-    def execute(self, code: str, cell_idx: int, user_expressions: Optional[Dict[str, str]] = None) -> Optional[str]:
+    def execute(
+        self,
+        code: str,
+        cell_id: str,
+        user_expressions: Optional[Dict[str, str]] = None,
+    ) -> Optional[str]:
         """Execute code in the kernel with optional user_expressions for namespace capture."""
         if not self.kernel_client:
             self.send_message({
                 "type": "error",
-                "error": "No kernel connected"
+                "error": "No kernel connected",
+                "cell_id": cell_id
             })
             return None
 
         try:
             msg_id = self.kernel_client.execute(code, user_expressions=user_expressions or {})
             self.pending_executions[msg_id] = {
-                "cell_idx": cell_idx,
+                "cell_id": cell_id,
                 "code": code,
                 "has_user_expressions": bool(user_expressions)
             }
             self.send_message({
                 "type": "execute_request",
-                "cell_idx": cell_idx,
+                "cell_id": cell_id,
                 "msg_id": msg_id
             })
 
             # If user_expressions provided, wait for execute_reply on shell channel
             if user_expressions:
-                self._wait_for_execute_reply(msg_id, cell_idx)
+                self._wait_for_execute_reply(msg_id, cell_id)
 
             return msg_id
         except Exception as e:
             self.send_message({
                 "type": "error",
                 "error": f"Execution failed: {str(e)}",
-                "cell_idx": cell_idx
+                "cell_id": cell_id
             })
             return None
 
-    def _wait_for_execute_reply(self, msg_id: str, cell_idx: int):
+    def _wait_for_execute_reply(self, msg_id: str, cell_id: str):
         """Wait for execute_reply on shell channel and extract user_expressions results."""
         try:
             # Poll shell channel for the execute_reply (with timeout)
@@ -257,7 +266,7 @@ class KernelBridge:
                             ns_data = ns_result.get("data", {}).get("text/plain", "{}")
                             self.send_message({
                                 "type": "namespace",
-                                "cell_idx": cell_idx,
+                                "cell_id": cell_id,
                                 "namespace_repr": ns_data
                             })
                         elif ns_result.get("status") == "error":
@@ -459,9 +468,15 @@ def main():
 
             elif action == "execute":
                 code = cmd.get("code", "")
-                cell_idx = cmd.get("cell_idx", 0)
+                cell_id = cmd.get("cell_id")
+                if not isinstance(cell_id, str) or not cell_id:
+                    bridge.send_message({
+                        "type": "error",
+                        "error": "Missing required cell_id for execute action"
+                    })
+                    continue
                 user_expressions = cmd.get("user_expressions")
-                bridge.execute(code, cell_idx, user_expressions)
+                bridge.execute(code, cell_id, user_expressions)
 
             elif action == "interrupt":
                 bridge.interrupt()

--- a/python/kernel_bridge.py
+++ b/python/kernel_bridge.py
@@ -10,6 +10,7 @@ import json
 import sys
 import threading
 import queue
+import uuid
 from typing import Optional, Dict, Any
 
 from inspect_parsers import get_parser
@@ -36,6 +37,8 @@ class KernelBridge:
         self.execution_count: int = 0
         self.pending_executions: Dict[str, Dict[str, Any]] = {}
         self.iopub_thread: Optional[threading.Thread] = None
+        self.stdin_thread: Optional[threading.Thread] = None
+        self.pending_input_requests: Dict[str, Dict[str, Any]] = {}
         self.running = True
         self.output_queue = queue.Queue()
 
@@ -57,6 +60,7 @@ class KernelBridge:
 
             # Start iopub listener thread
             self._start_iopub_listener()
+            self._start_stdin_listener()
 
             # Get language from kernelspec
             language = None
@@ -90,6 +94,7 @@ class KernelBridge:
             self.kernel_client.wait_for_ready(timeout=30)
 
             self._start_iopub_listener()
+            self._start_stdin_listener()
 
             language = None
             try:
@@ -129,6 +134,35 @@ class KernelBridge:
         self.iopub_thread = threading.Thread(target=listener, daemon=True)
         self.iopub_thread.start()
 
+    def _start_stdin_listener(self):
+        """Start a thread to listen for stdin messages."""
+        def listener():
+            while self.running and self.kernel_client:
+                try:
+                    msg = self.kernel_client.get_stdin_msg(timeout=0.5)
+                    self._handle_stdin_message(msg)
+                except queue.Empty:
+                    continue
+                except Exception as e:
+                    if self.running:
+                        self.send_message({
+                            "type": "error",
+                            "error": f"Stdin listener error: {str(e)}"
+                        })
+
+        self.stdin_thread = threading.Thread(target=listener, daemon=True)
+        self.stdin_thread.start()
+
+    def _clear_input_requests_for_msg(self, msg_id: str):
+        """Remove pending stdin requests associated with an execution message."""
+        to_remove = [
+            request_id
+            for request_id, request in self.pending_input_requests.items()
+            if request.get("msg_id") == msg_id
+        ]
+        for request_id in to_remove:
+            self.pending_input_requests.pop(request_id, None)
+
     def _handle_iopub_message(self, msg: Dict[str, Any]):
         """Handle a message from the iopub channel."""
         msg_type = msg.get("msg_type", "")
@@ -150,6 +184,7 @@ class KernelBridge:
             if execution_state == "idle":
                 # Execution is complete, drop tracking to prevent unbounded growth.
                 self.pending_executions.pop(msg_id, None)
+                self._clear_input_requests_for_msg(msg_id)
 
         elif msg_type == "stream":
             self.send_message({
@@ -204,6 +239,32 @@ class KernelBridge:
                 "cell_id": cell_id,
                 "execution_count": content.get("execution_count")
             })
+
+    def _handle_stdin_message(self, msg: Dict[str, Any]):
+        """Handle a message from the stdin channel."""
+        if msg.get("msg_type") != "input_request":
+            return
+
+        content = msg.get("content", {})
+        parent_header = msg.get("parent_header", {})
+        parent_msg_id = parent_header.get("msg_id", "")
+
+        exec_info = self.pending_executions.get(parent_msg_id, {})
+        cell_id = exec_info.get("cell_id")
+
+        request_id = uuid.uuid4().hex
+        self.pending_input_requests[request_id] = {
+            "msg_id": parent_msg_id,
+            "cell_id": cell_id,
+        }
+
+        self.send_message({
+            "type": "input_request",
+            "request_id": request_id,
+            "cell_id": cell_id,
+            "prompt": content.get("prompt", ""),
+            "password": bool(content.get("password", False)),
+        })
 
     def execute(
         self,
@@ -285,6 +346,7 @@ class KernelBridge:
         if self.kernel_manager:
             try:
                 self.kernel_manager.interrupt_kernel()
+                self.pending_input_requests.clear()
                 self.send_message({"type": "interrupted"})
             except Exception as e:
                 self.send_message({
@@ -300,6 +362,7 @@ class KernelBridge:
                 self.kernel_client.wait_for_ready(timeout=30)
                 self.execution_count = 0
                 self.pending_executions.clear()
+                self.pending_input_requests.clear()
                 self.send_message({"type": "restarted"})
             except Exception as e:
                 self.send_message({
@@ -310,6 +373,7 @@ class KernelBridge:
     def shutdown(self):
         """Shutdown the kernel."""
         self.running = False
+        self.pending_input_requests.clear()
         if self.kernel_client:
             self.kernel_client.stop_channels()
         if self.kernel_manager:
@@ -318,6 +382,31 @@ class KernelBridge:
             except Exception:
                 pass
         self.send_message({"type": "shutdown"})
+
+    def input_reply(self, request_id: str, value: str):
+        """Send stdin reply for a pending input request."""
+        if not self.kernel_client:
+            self.send_message({
+                "type": "error",
+                "error": "No kernel connected"
+            })
+            return
+
+        if request_id not in self.pending_input_requests:
+            self.send_message({
+                "type": "error",
+                "error": f"Unknown input request_id: {request_id}"
+            })
+            return
+
+        try:
+            self.kernel_client.input(value)
+            self.pending_input_requests.pop(request_id, None)
+        except Exception as e:
+            self.send_message({
+                "type": "error",
+                "error": f"Failed to send input reply: {str(e)}"
+            })
 
     def get_kernel_info(self):
         """Get kernel information."""
@@ -508,6 +597,19 @@ def main():
                 detail_level = cmd.get("detail_level", 0)
                 request_id = cmd.get("request_id")
                 bridge.inspect(code, cursor_pos, detail_level, request_id)
+
+            elif action == "input_reply":
+                request_id = cmd.get("request_id")
+                value = cmd.get("value", "")
+                if not isinstance(request_id, str) or not request_id:
+                    bridge.send_message({
+                        "type": "error",
+                        "error": "Missing required request_id for input_reply action"
+                    })
+                    continue
+                if not isinstance(value, str):
+                    value = str(value)
+                bridge.input_reply(request_id, value)
 
             elif action == "ping":
                 bridge.send_message({"type": "pong"})

--- a/tests/run_all.lua
+++ b/tests/run_all.lua
@@ -46,6 +46,26 @@ local function lazy_path()
   return join(app_data_dir(), 'lazy/lazy.nvim')
 end
 
+local function bootstrap_ready()
+  if not vim.loop.fs_stat(lazy_path()) then
+    return false
+  end
+
+  local lazy_root = join(app_data_dir(), 'lazy')
+  local required = {
+    join(lazy_root, 'nvim-treesitter'),
+    join(lazy_root, 'nvim-lspconfig'),
+  }
+
+  for _, path in ipairs(required) do
+    if not vim.loop.fs_stat(path) then
+      return false
+    end
+  end
+
+  return true
+end
+
 local function bootstrap_lazy()
   if not exe('git') then
     print('WARN: git not found; skipping bootstrap')
@@ -53,11 +73,17 @@ local function bootstrap_lazy()
   end
 
   local target = lazy_path()
-  if vim.loop.fs_stat(target) then
+  local lazy_entry = join(target, 'lua/lazy/init.lua')
+  if vim.loop.fs_stat(lazy_entry) then
     return true
   end
 
-  vim.fn.mkdir(target, 'p')
+  if vim.loop.fs_stat(target) then
+    print('WARN: found incomplete lazy.nvim checkout; re-cloning')
+    vim.fn.delete(target, 'rf')
+  end
+
+  vim.fn.mkdir(vim.fn.fnamemodify(target, ':h'), 'p')
   local result = vim.system({
     'git',
     'clone',
@@ -72,6 +98,11 @@ local function bootstrap_lazy()
     if result.stderr and result.stderr ~= '' then
       print(result.stderr)
     end
+    return false
+  end
+
+  if not vim.loop.fs_stat(lazy_entry) then
+    print('WARN: lazy.nvim clone missing expected files')
     return false
   end
 
@@ -113,6 +144,11 @@ local function bootstrap_plugins()
     return false
   end
 
+  if not bootstrap_ready() then
+    print('WARN: bootstrap completed but required plugins are still missing')
+    return false
+  end
+
   return true
 end
 
@@ -151,12 +187,10 @@ local function ensure_venv_lsp()
     vim.system({ pip, 'install', '--upgrade', 'pip' }, { text = true }):wait()
     vim.system({ pip, 'install', 'basedpyright' }, { text = true }):wait()
   end
-
   local ruff = venv_bin(venv_dir, 'ruff')
   if not vim.loop.fs_stat(ruff) then
     vim.system({ pip, 'install', 'ruff' }, { text = true }):wait()
   end
-
   if vim.loop.fs_stat(basedpyright) then
     vim.env.IPYNB_TEST_LSP_BIN = basedpyright
     vim.env.IPYNB_TEST_LSP_ARGS = '--stdio'
@@ -324,7 +358,7 @@ end
 ensure_env()
 
 if vim.env.IPYNB_TEST_SKIP_BOOTSTRAP ~= '1' then
-  if vim.env.IPYNB_TEST_FORCE_BOOTSTRAP == '1' or not vim.loop.fs_stat(lazy_path()) then
+  if vim.env.IPYNB_TEST_FORCE_BOOTSTRAP == '1' or not bootstrap_ready() then
     bootstrap_plugins()
   else
     print('Bootstrap already present; skipping. Set IPYNB_TEST_FORCE_BOOTSTRAP=1 to force.')
@@ -345,6 +379,7 @@ local tests = {
   join(root, 'tests/test_modified.lua'),
   join(root, 'tests/test_undo.lua'),
   join(root, 'tests/test_io.lua'),
+  join(root, 'tests/test_shadow.lua'),
   join(root, 'tests/test_lsp.lua'),
   join(root, 'tests/test_lsp_go.lua'),
   join(root, 'tests/test_treesitter_autoinstall.lua'),

--- a/tests/test_kernel_bridge.py
+++ b/tests/test_kernel_bridge.py
@@ -81,8 +81,16 @@ class KernelBridgeTest:
         start = time.time()
         while time.time() - start < timeout:
             msg = self.read_message(timeout=0.5)
-            if msg and msg.get("type") == msg_type:
+            if not msg:
+                continue
+
+            if msg.get("type") == msg_type:
                 return msg
+
+            if msg.get("type") == "error":
+                raise AssertionError(
+                    f"Bridge error while waiting for '{msg_type}': {msg.get('error', 'Unknown error')}"
+                )
         return None
 
 
@@ -148,7 +156,7 @@ def test_code_execution():
         bridge.send({
             "action": "execute",
             "code": "print('Hello from test!')",
-            "cell_idx": 0
+            "cell_id": "cell-0"
         })
 
         # Collect messages until idle
@@ -193,7 +201,7 @@ def test_execution_count():
             bridge.send({
                 "action": "execute",
                 "code": f"x = {i}",
-                "cell_idx": i
+                "cell_id": f"cell-{i}"
             })
             # Wait for idle
             while True:
@@ -205,7 +213,7 @@ def test_execution_count():
         bridge.send({
             "action": "execute",
             "code": "y = 2",
-            "cell_idx": 2
+            "cell_id": "cell-2"
         })
 
         exec_input = bridge.wait_for_message("execute_input", timeout=10)
@@ -232,7 +240,7 @@ def test_execute_result():
         bridge.send({
             "action": "execute",
             "code": "1 + 1",
-            "cell_idx": 0
+            "cell_id": "cell-0"
         })
 
         # Collect until idle
@@ -274,7 +282,7 @@ def test_error_handling():
         bridge.send({
             "action": "execute",
             "code": "undefined_variable",
-            "cell_idx": 0
+            "cell_id": "cell-0"
         })
 
         # Collect until idle
@@ -316,7 +324,7 @@ def test_interrupt():
         bridge.send({
             "action": "execute",
             "code": "import time; time.sleep(60)",
-            "cell_idx": 0
+            "cell_id": "cell-0"
         })
 
         # Wait for busy state
@@ -350,7 +358,7 @@ def test_restart():
         bridge.send({
             "action": "execute",
             "code": "test_var = 'before_restart'",
-            "cell_idx": 0
+            "cell_id": "cell-before-restart"
         })
         while True:
             msg = bridge.read_message(timeout=10)
@@ -378,7 +386,7 @@ def test_restart():
         bridge.send({
             "action": "execute",
             "code": "test_var",
-            "cell_idx": 1
+            "cell_id": "cell-after-restart"
         })
 
         # Should get error (variable doesn't exist)

--- a/tests/test_kernel_bridge.py
+++ b/tests/test_kernel_bridge.py
@@ -309,6 +309,60 @@ def test_error_handling():
         bridge.stop()
 
 
+def test_stdin_input_request_reply():
+    """Test input_request/input_reply roundtrip."""
+    bridge = KernelBridgeTest()
+    try:
+        bridge.start()
+        bridge.read_message()  # consume ready
+
+        # Start kernel
+        bridge.send({"action": "start", "kernel_name": "python3"})
+        bridge.wait_for_message("kernel_started", timeout=30)
+
+        # Execute code that requires stdin input
+        bridge.send({
+            "action": "execute",
+            "code": "name = input('Name: '); print('Hello', name)",
+            "cell_id": "cell-input"
+        })
+
+        input_req = bridge.wait_for_message("input_request", timeout=10)
+        assert input_req is not None, "Missing input_request"
+        assert input_req.get("request_id"), "Missing request_id in input_request"
+        assert "Name:" in input_req.get("prompt", ""), "Unexpected prompt"
+
+        bridge.send({
+            "action": "input_reply",
+            "request_id": input_req["request_id"],
+            "value": "Mohan",
+        })
+
+        messages = []
+        while True:
+            msg = bridge.read_message(timeout=10)
+            if msg is None:
+                break
+            messages.append(msg)
+            if msg.get("type") == "status" and msg.get("state") == "idle":
+                break
+
+        output_msg = next(
+            (
+                m for m in messages
+                if m.get("type") == "output"
+                and m.get("output", {}).get("output_type") == "stream"
+                and "Hello Mohan" in m.get("output", {}).get("text", "")
+            ),
+            None,
+        )
+        assert output_msg is not None, "Missing expected stream output after input_reply"
+
+        print("PASS: Stdin input_request/input_reply works")
+    finally:
+        bridge.stop()
+
+
 def test_interrupt():
     """Test kernel interrupt."""
     bridge = KernelBridgeTest()
@@ -421,6 +475,7 @@ def run_all_tests():
         test_execution_count,
         test_execute_result,
         test_error_handling,
+        test_stdin_input_request_reply,
         test_interrupt,
         test_restart,
     ]

--- a/tests/test_modified.lua
+++ b/tests/test_modified.lua
@@ -183,6 +183,42 @@ h.run_test('changedtick_prevents_spurious_sync', function()
 end)
 
 --------------------------------------------------------------------------------
+-- Test: Name collision does not block edit mode (E95 regression)
+-- Create a conflicting hidden buffer with the exact target name, then open edit.
+-- Expected: edit opens successfully and write still works.
+--------------------------------------------------------------------------------
+h.run_test('edit_name_collision_no_e95', function()
+  local state = h.open_notebook('simple.ipynb')
+  local cell = state.cells[1]
+  h.assert_true(cell ~= nil and cell.id ~= nil, 'Cell 1 should have a stable id')
+
+  local notebook_name = vim.fn.fnamemodify(state.source_path, ':t')
+  local collision_name = string.format('[%s:%s]', notebook_name, cell.id)
+
+  -- Simulate stale conflicting buffer left behind by previous session.
+  local conflict = vim.api.nvim_create_buf(false, false)
+  vim.api.nvim_buf_set_name(conflict, collision_name)
+  vim.bo[conflict].bufhidden = 'hide'
+  vim.api.nvim_buf_set_lines(conflict, 0, -1, false, { 'FOREIGN BUFFER' })
+
+  local ok, err = pcall(function()
+    h.enter_cell(1)
+  end)
+  h.assert_true(ok, 'Entering edit should not fail with E95: ' .. tostring(err))
+
+  local edit_buf = h.get_edit_buf()
+  h.assert_true(edit_buf ~= nil and vim.api.nvim_buf_is_valid(edit_buf), 'Should open a valid edit buffer')
+  h.assert_false(edit_buf == conflict, 'Should not reuse a foreign conflicting buffer')
+
+  local content = h.get_edit_buffer_content() or ''
+  h.assert_false(content == 'FOREIGN BUFFER', 'Edit buffer content should come from the cell, not conflict buffer')
+
+  -- Verify write support is configured on the resulting edit buffer.
+  local write_cmds = vim.api.nvim_get_autocmds({ event = 'BufWriteCmd', buffer = edit_buf })
+  h.assert_true(#write_cmds > 0, 'Edit buffer should have BufWriteCmd handler')
+end)
+
+--------------------------------------------------------------------------------
 -- Print summary and exit
 --------------------------------------------------------------------------------
 local success = h.summary()

--- a/tests/test_shadow.lua
+++ b/tests/test_shadow.lua
@@ -1,0 +1,72 @@
+-- Focused tests for shadow file write behavior
+
+local h = require('tests.helpers')
+
+print('=' .. string.rep('=', 59))
+print('Running shadow write tests')
+print('=' .. string.rep('=', 59))
+
+h.run_test('shadow_write_is_debounced', function()
+  h.open_notebook('mixed.ipynb')
+  local state = h.get_state()
+  local cells_mod = require('ipynb.cells')
+  local shadow = require('ipynb.lsp.shadow')
+
+  local cfg = require('ipynb.config').get()
+  local prev_delay = cfg.shadow.debounce_ms
+  cfg.shadow.debounce_ms = 400
+
+  local content_start, content_end = cells_mod.get_content_range(state, 1)
+  h.assert_true(content_start ~= nil and content_end ~= nil, 'Cell content range should exist')
+
+  local before_disk = vim.fn.readfile(state.shadow_path)
+  local probe = '__debounce_probe__'
+  shadow.sync_shadow_region(state, content_start, content_end + 1, { probe }, 'code')
+
+  -- Shadow buffer should update immediately (for LSP responsiveness).
+  local in_memory = vim.api.nvim_buf_get_lines(state.shadow_buf, content_start, content_start + 1, false)[1]
+  h.assert_eq(in_memory, probe, 'Shadow buffer should update immediately')
+
+  -- Shadow file should not update immediately (debounced disk write).
+  local immediate_disk = vim.fn.readfile(state.shadow_path)
+  h.assert_eq(table.concat(immediate_disk, '\n'), table.concat(before_disk, '\n'),
+    'Shadow file should not be written immediately')
+
+  local wrote = vim.wait(1500, function()
+    local lines = vim.fn.readfile(state.shadow_path)
+    return lines[content_start + 1] == probe
+  end, 50)
+  h.assert_true(wrote, 'Debounced shadow write should flush to disk')
+
+  cfg.shadow.debounce_ms = prev_delay
+end)
+
+h.run_test('flush_shadow_write_forces_disk_sync', function()
+  h.open_notebook('mixed.ipynb')
+  local state = h.get_state()
+  local cells_mod = require('ipynb.cells')
+  local shadow = require('ipynb.lsp.shadow')
+
+  local cfg = require('ipynb.config').get()
+  local prev_delay = cfg.shadow.debounce_ms
+  cfg.shadow.debounce_ms = 400
+
+  local content_start, content_end = cells_mod.get_content_range(state, 1)
+  h.assert_true(content_start ~= nil and content_end ~= nil, 'Cell content range should exist')
+
+  local probe = '__flush_probe__'
+  shadow.sync_shadow_region(state, content_start, content_end + 1, { probe }, 'code')
+  shadow.flush_shadow_write(state)
+
+  local disk_lines = vim.fn.readfile(state.shadow_path)
+  h.assert_eq(disk_lines[content_start + 1], probe, 'Flush should write pending shadow changes immediately')
+
+  cfg.shadow.debounce_ms = prev_delay
+end)
+
+local success = h.summary()
+if success then
+  vim.cmd('qa!')
+else
+  vim.cmd('cquit 1')
+end


### PR DESCRIPTION
## Summary
This PR bundles four fixes across output rendering, kernel message routing, LSP shadow-file syncing, and edit-float viewport fix:
1. Stream outputs now preserve blank lines in inline rendering.
2. Kernel execution/output routing now uses stable cell_id instead of positional index.
3. Shadow file writes are debounced to avoid full-file disk writes on every edit keystroke.
4. keep edit-float viewport anchored when adding lines with o/O
## Changes
### 1) Stream outputs keep blank lines
  - Fixed inline stream rendering logic so empty lines are not dropped.
  - Replaced newline splitting based on gmatch('[^\n]+') with plain split behavior that preserves empty segments.
  - Applied in both stream render path and output text build path.

  ### 2) Execution routing uses stable cell_id
  - Switched execute request flow from cell_idx to cell_id between Lua and Python bridge.
  - Added robust message-to-cell resolution in Lua using current state at message arrival.
  - Added/reused cell_id -> index mapping with rebuild-on-stale behavior.
  - If a cell no longer exists, output is dropped instead of being misrouted.
  - Bridge now emits cell_id on execution-related messages.
  - pending_executions is cleaned when execution reaches idle.
  - **Add a cached cell_id -> index map to avoid linear scan overhead** 

  ### 3) Debounced shadow writes

  - Added debounced shadow disk writes (shadow.debounce_ms, default 400).
  - sync_shadow_region updates shadow buffer immediately, but defers disk write.
  - Added explicit flush_shadow_write and flush before formatting requests.
  - Added timer lifecycle cleanup when notebook state is removed.

### 4)keep edit-float viewport anchored
- #### Root Cause
  When a 1-line edit float grows, Neovim may temporarily have `topline=2`. The resize helper restored the full previous window view (`winsaveview`/ `winrestview`) and kept that stale `topline`, causing the first line to be clipped.
- #### Fix
  - In edit-float resize logic, keep normal view restoration but force `view.topline = 1` before `winrestview(view)`.
  - This preserves cursor/column while anchoring the float viewport to the first line of the cell.

### 5) Tests and test-runner updates
- Updated bridge tests for cell_id execute path.
- Added focused shadow write tests (tests/test_shadow.lua) and included
  them in tests/run_all.lua.
- Improved bootstrap checks in test runner for incomplete lazy/plugin
  bootstrap states.

## Validation

- `uv run python tests/test_kernel_bridge.py` passed.
- `nvim --headless -u tests/minimal_init.lua -l tests/test_shadow.lua` passed.
- `nvim --headless -u tests/minimal_init.lua -l tests/test_modified.lua` passed.