### PR TITLE
Remove snacks.nvim 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Thanks for your interest in contributing!
 
 - Neovim 0.10+
   - `nvim-treesitter` for tree-sitter support
-  - `snacks.nvim` for image rendering and colorized inspect
+  - `image.nvim` for image rendering and colorized inspect
 - a language server (e.g. basedpyright/pyright, julials, r_language_server)
 - Python 3.x (for kernel bridge + tests that touch Python)
   - `jupyter_client`, `nbformat` (we recommend installing via `uv` and the project's `pyproject.toml`)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Under the hood, the notebook is rendered into a single buffer for display. Enter
 
 - [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) for LSP support (completion, diagnostics, etc.)
 - [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons) for language icons in cell borders
-- [snacks.nvim](https://github.com/folke/snacks.nvim) for inline image rendering
+- [image.nvim](https://github.com/3rd/image.nvim) for inline image rendering
   - a terminal that fully supports the kitty graphics protocol (e.g., kitty, Ghostty)
   - ImageMagick required to display non-PNG image formats
 
@@ -53,7 +53,7 @@ Run `:checkhealth ipynb` to verify your setup.
     "nvim-treesitter/nvim-treesitter",
     "neovim/nvim-lspconfig",
     -- "nvim-tree/nvim-web-devicons", -- optional, for language icons
-    -- "folke/snacks.nvim", -- optional, for inline images
+    -- "3rd/image.nvim", -- optional, for inline images
   },
   opts = {},
 }
@@ -397,13 +397,13 @@ Press `<Esc>` / `<C-c>` to cancel (the plugin interrupts the kernel).
 
 **Images not showing**
 
-Requires snacks.nvim and a terminal which fully supports the kitty graphics protocol (kitty, Ghostty). For tmux, set `allow-passthrough=on`.
+Requires image.nvim and a terminal which fully supports the kitty graphics protocol (kitty, Ghostty). For tmux, set `allow-passthrough=on`.
 
 **`[Image failed to load]` even when terminal support is true**
 
-If `:lua print(require("snacks").image.supports_terminal())` returns `true` but images still fail:
+If `:lua print(require("image").is_enabled())` returns `true` but images still fail:
 
-- Run `:checkhealth snacks` (not just `:checkhealth ipynb`)
+- Run `:checkhealth image` (not just `:checkhealth ipynb`)
 - Ensure ImageMagick tools are installed (`magick`/`convert`) for non-PNG conversion
 
 ## 🗺️ Roadmap

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -1246,7 +1246,7 @@ function M.render_output(output)
 
   elseif output.output_type == 'display_data' then
     if output.data['image/png'] then
-      -- Image rendered inline via images.lua if snacks.nvim available
+      -- Image rendered inline via images.lua if image.nvim available
       -- Falls back to placeholder text if not
     else
       table.insert(lines, {{ output.data['text/plain'] or '[Display]', 'IpynbOutput' }})
@@ -1317,7 +1317,7 @@ The terminal renders images by replacing special Unicode placeholder characters 
 - Placement ID encoded in highlight group's `sp` color
 
 ```lua
--- Vendored from snacks.nvim - generates placeholder grid
+-- Vendored Kitty Graphics Protocol placeholder generation
 local function generate_placeholder_grid(img_id, placement_id, width, height)
   -- Create highlight group with IDs encoded in colors
   local hl_group = 'IpynbImage' .. placement_id

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -130,7 +130,7 @@ lua/ipynb/
 ├── keymaps.lua        # Keymap definitions
 ├── kernel.lua         # Jupyter kernel connection (per-notebook state)
 ├── output.lua         # Cell output rendering
-├── images.lua         # Image output rendering (via snacks.nvim)
+├── images.lua         # Image output rendering (via image.nvim)
 ├── inspector.lua      # Variable inspector (Jupyter inspect protocol)
 ├── folding.lua        # Cell folding support
 ├── picker.lua         # Cell picker (vim.ui.select)
@@ -1291,9 +1291,9 @@ end
 
 ### 11. Image Rendering (`images.lua`)
 
-**Inline image rendering using snacks.nvim (optional dependency):**
+**Inline image rendering using image.nvim (optional dependency):**
 
-Images are rendered inline within cell outputs using the Kitty Graphics Protocol (supported by kitty, ghostty, wezterm). The implementation uses vendored placeholder generation from snacks.nvim to enable true text/image interleaving.
+Images are rendered inline within cell outputs using the Kitty Graphics Protocol (supported by kitty, ghostty, wezterm). The implementation uses vendored placeholder generation to enable true text/image interleaving.
 
 **Key design decisions:**
 
@@ -1303,9 +1303,9 @@ Images are rendered inline within cell outputs using the Kitty Graphics Protocol
 
 3. **Single extmark with all content**: All cell output (separator, text lines, image placeholder lines) is combined into a single extmark's `virt_lines` array. Order is guaranteed by array order.
 
-4. **Actual terminal cell dimensions**: Uses `Snacks.image.terminal.size()` to get real terminal cell dimensions for accurate pixel-to-cell conversion. This ensures the placeholder grid size matches what the terminal allocates.
+4. **Actual terminal cell dimensions**: Uses `image.utils.term.get_size()` to get real terminal cell dimensions for accurate pixel-to-cell conversion. This ensures the placeholder grid size matches what the terminal allocates.
 
-5. **Snacks dimensions as source of truth**: We use `img.info.size` from snacks' converted image for dimensions. For SVGs, ImageMagick converts at 192 DPI which may differ from declared pt values. Using snacks' dimensions ensures the placeholder grid matches the actual image pixels, preventing placement misalignment. Images are scaled down proportionally to fit the terminal width.
+5. **Image.nvim dimensions as source of truth**: We use `img.image_width` and `img.image_height` from image.nvim for dimensions. For SVGs, ImageMagick converts at 192 DPI which may differ from declared pt values. Using image.nvim's dimensions ensures the placeholder grid matches the actual image pixels, preventing placement misalignment. Images are scaled down proportionally to fit the terminal width.
 
 **How Kitty Graphics Protocol placeholders work:**
 
@@ -1344,18 +1344,14 @@ end
 -- Generate virt_lines entries for an image
 function M.get_image_virt_lines(state, cell, output, image_index)
   -- 1. Decode image data and write to cache file
-  -- 2. Create snacks Image object (handles loading/sending to terminal)
+  -- 2. Create image.nvim Image object
   -- 3. Send placement command via Kitty Graphics Protocol
   -- 4. Generate placeholder grid lines
   -- 5. Return as virt_lines entries for interleaving
 
-  local img = get_or_create_image(path)  -- snacks handles terminal protocol
+  local img = get_or_create_image(path)  -- image.nvim handles loading/conversion
 
-  Snacks.image.terminal.request({
-    a = 'p', U = 1,
-    i = img.id, p = placement_id,
-    c = img_width, r = img_height,
-  })
+  send_placement_request(internal_id, placement_id, img_width, img_height)
 
   local placeholder_lines, hl_group = generate_placeholder_grid(
     img.id, placement_id, img_width, img_height
@@ -1403,10 +1399,10 @@ cell.output_extmark = vim.api.nvim_buf_set_extmark(buf, ns, end_line, 0, {
 **Key features:**
 
 - True text/image interleaving (text1 → img1 → text2 → img2 works correctly)
-- Gracefully degrades to placeholder text if snacks.nvim not installed or terminal lacks placeholder support
+- Gracefully degrades to placeholder text if image.nvim not installed or terminal lacks placeholder support
 - Caches decoded images in `~/.cache/nvim/ipynb.nvim/`
 - Supports PNG, JPEG, GIF, WebP, BMP, TIFF, HEIC, AVIF, SVG, and PDF formats
-- SVG and PDF are converted to raster via ImageMagick (handled by snacks.nvim)
+- SVG and PDF are converted to raster via ImageMagick (handled by image.nvim)
 - Uses actual terminal cell dimensions for accurate sizing
 - Images persist through cell moves, insertions, deletions (via unique cell IDs)
 - Requires terminal with Kitty Graphics Protocol + Unicode placeholder support (kitty, ghostty)
@@ -1522,7 +1518,7 @@ def inspect(self, code: str, cursor_pos: int, detail_level: int = 0):
 
 - Parsers live in `python/inspect_parsers/` and return a normalized `InspectSections` dataclass.
 - `get_parser(language, kernel_name)` routes to a parser; fallback is raw.
-- Raw output sets `_raw=true` and `_clean` (ANSI-stripped) to support non-Snacks setups.
+- Raw output sets `_raw=true` and `_clean` (ANSI-stripped) to support non-image setups.
 
 **Identifier detection:**
 
@@ -1601,4 +1597,4 @@ require('ipynb').setup({
 **Optional:**
 
 - nvim-web-devicons (language icons in cell borders)
-- snacks.nvim (image rendering)
+- image.nvim (image rendering)

--- a/doc/ipynb.txt
+++ b/doc/ipynb.txt
@@ -25,7 +25,7 @@ Features:
 - Blocking stdin prompts (`input()`), with secure fallback for password prompts
 - Variable inspector using Jupyter inspect protocol (with auto-hover)
 - Multi-language support (Python, Julia, R, etc.)
-- Inline image rendering (requires snacks.nvim)
+- Inline image rendering (requires image.nvim)
 - Cell folding to collapse cell content
 - Tree-sitter based syntax highlighting
 
@@ -239,7 +239,7 @@ KernelConfig                                                      *KernelConfig*
 ------------------------------------------------------------------------------
 ImageConfig                                                        *ImageConfig*
 
-    Requires snacks.nvim for inline image rendering in terminals that
+    Requires image.nvim for inline image rendering in terminals that
     support the kitty graphics protocol.
 
     Fields: ~
@@ -519,7 +519,7 @@ Kernel won't start ~
 
 Images not showing ~
 
-    Requires snacks.nvim and a terminal which fully supports the kitty graphics protocol
+    Requires image.nvim and a terminal which fully supports the kitty graphics protocol
     (kitty, Ghostty). For tmux, set `allow-passthrough=on`.
 
 ==============================================================================

--- a/lua/ipynb/config.lua
+++ b/lua/ipynb/config.lua
@@ -92,7 +92,7 @@ local M = {}
 ---@field python_path string|nil Custom Python path for kernel bridge
 
 ---@class ImageConfig
----@field enabled boolean Enable image rendering (requires snacks.nvim)
+---@field enabled boolean Enable image rendering (requires image.nvim)
 ---@field cache_dir string Directory to cache decoded images
 ---@field max_width number|nil Maximum image width in terminal columns (nil = window width minus sign/number columns)
 ---@field max_height number|nil Maximum image height in terminal rows (nil = window height minus scrolloff minus 1)

--- a/lua/ipynb/health.lua
+++ b/lua/ipynb/health.lua
@@ -108,27 +108,12 @@ local function check_optional()
     health.info('nvim-web-devicons not installed (optional, for language icons)')
   end
 
-  -- snacks.nvim for images
-  local snacks_ok, Snacks = pcall(require, 'snacks')
-  if snacks_ok then
-    local has_image = Snacks.image and Snacks.image.placement
-    if has_image then
-      -- Check terminal support
-      local terminal_supported = true
-      if Snacks.image.supports_terminal then
-        terminal_supported = Snacks.image.supports_terminal()
-      end
-
-      if terminal_supported then
-        health.ok('snacks.nvim image support available')
-      else
-        health.info('snacks.nvim installed but terminal does not support images (requires kitty graphics protocol)')
-      end
-    else
-      health.info('snacks.nvim installed but image module not available')
-    end
+  -- image.nvim for images
+  local image_ok, image_api = pcall(require, 'image')
+  if image_ok and image_api then
+    health.ok('image.nvim available')
   else
-    health.info('snacks.nvim not installed (optional, for inline images)')
+    health.info('image.nvim not installed (optional, for inline images)')
   end
 end
 

--- a/lua/ipynb/health.lua
+++ b/lua/ipynb/health.lua
@@ -111,9 +111,26 @@ local function check_optional()
   -- image.nvim for images
   local image_ok, image_api = pcall(require, 'image')
   if image_ok and image_api then
-    health.ok('image.nvim available')
+    -- Verify setup() was called by probing from_file
+    local setup_ok = pcall(image_api.from_file, '/dev/null')
+    if setup_ok then
+      health.ok('image.nvim available and configured')
+    else
+      health.warn('image.nvim installed but setup() not called', {
+        'Add require("image").setup() to your config',
+        'Without setup(), inline images will not render',
+      })
+    end
   else
     health.info('image.nvim not installed (optional, for inline images)')
+  end
+
+  -- ImageMagick for non-PNG image format conversion
+  local magick_ok = vim.fn.executable('magick') == 1 or vim.fn.executable('convert') == 1
+  if magick_ok then
+    health.ok('ImageMagick found (for non-PNG image formats)')
+  else
+    health.info('ImageMagick not found (optional, needed for JPEG/SVG/PDF image conversion)')
   end
 end
 

--- a/lua/ipynb/images.lua
+++ b/lua/ipynb/images.lua
@@ -1,5 +1,7 @@
 -- ipynb/images.lua - Image output rendering using image.nvim
--- Uses vendored placeholder generation for true text/image interleaving in virt_lines
+-- Uses image.nvim for dimension reading and image object lifecycle,
+-- with direct Kitty Graphics Protocol commands for terminal transmission.
+-- Uses vendored placeholder generation for true text/image interleaving in virt_lines.
 
 local M = {}
 
@@ -8,12 +10,12 @@ local M = {}
 --------------------------------------------------------------------------------
 
 ---@class ImageNvim
----@field id string|number Image ID
----@field internal_id number Image ID for terminal protocol
+---@field id string Image string ID
+---@field internal_id number Image ID for terminal protocol (Kitty image ID)
 ---@field image_width number Pixel width
 ---@field image_height number Pixel height
 ---@field path string File path
----@field render fun(self: ImageNvim, geometry?: table)
+---@field source_format string|nil Original image format (png, jpeg, etc.)
 ---@field clear fun(self: ImageNvim, shallow?: boolean)
 
 --------------------------------------------------------------------------------
@@ -23,7 +25,7 @@ local ns = vim.api.nvim_create_namespace("ipynb_images")
 M.ns = ns
 
 --------------------------------------------------------------------------------
--- Vendored from image placeholder generation for Kitty Graphics Protocol
+-- Vendored Kitty Graphics Protocol placeholder generation
 -- This allows us to generate image placeholder text for use in our own virt_lines
 --------------------------------------------------------------------------------
 
@@ -55,7 +57,7 @@ local function next_placement_id()
 end
 
 ---Generate placeholder grid lines for an image
----@param img_id number The Image ID
+---@param img_id number The Kitty image ID
 ---@param placement_id number The placement ID
 ---@param width number Width in terminal cells
 ---@param height number Height in terminal cells
@@ -190,10 +192,115 @@ local function write_binary_file(path, data)
 	return ok_write ~= nil
 end
 
--- Storage for image.nvim Image objects
+--------------------------------------------------------------------------------
+-- Kitty Graphics Protocol helpers
+--------------------------------------------------------------------------------
+
+---Send a raw Kitty protocol escape sequence to the terminal (with tmux wrapping)
+---@param payload string Kitty graphics protocol payload (without outer escape wrapper)
+local function send_kitty_command(payload)
+	if vim.env.TMUX or vim.env.TMUX_PANE then
+		payload = "\x1bPtmux;\x1b" .. payload:gsub("\x1b", "\x1b\x1b") .. "\x1b\\"
+	end
+	io.stdout:write(payload)
+	io.stdout:flush()
+end
+
+---Transmit image file data to the terminal via Kitty direct (base64) method.
+---Reads the file, base64-encodes it, and sends in chunks.
+---@param img_id number Kitty image ID
+---@param file_path string Absolute path to image file on disk
+local function send_transmit_request(img_id, file_path)
+	local f = io.open(file_path, "rb")
+	if not f then
+		return
+	end
+	local data = f:read("*a")
+	f:close()
+	if not data or #data == 0 then
+		return
+	end
+
+	local b64 = vim.base64.encode(data)
+	local chunk_size = 4096
+	local total_chunks = math.ceil(#b64 / chunk_size)
+
+	for i = 1, total_chunks do
+		local start = (i - 1) * chunk_size + 1
+		local finish = math.min(i * chunk_size, #b64)
+		local chunk = b64:sub(start, finish)
+		local m = i < total_chunks and 1 or 0
+		local payload = string.format("\x1b_Ga=t,f=100,i=%d,t=d,m=%d,q=2;%s\x1b\\", img_id, m, chunk)
+		send_kitty_command(payload)
+	end
+end
+
+---Send Kitty placement command (display with Unicode placeholders)
+---@param img_id number Kitty image ID
+---@param placement_id number Placement ID
+---@param width number Width in terminal cells
+---@param height number Height in terminal cells
+local function send_placement_request(img_id, placement_id, width, height)
+	local payload = string.format(
+		"\x1b_Ga=p,U=1,i=%d,p=%d,C=1,c=%d,r=%d,q=2\x1b\\",
+		img_id,
+		placement_id,
+		width,
+		height
+	)
+	send_kitty_command(payload)
+end
+
+---Send Kitty delete placement command
+---@param img_id number Kitty image ID
+---@param placement_id number Placement ID
+local function send_clear_placement_request(img_id, placement_id)
+	local payload = string.format("\x1b_Ga=d,d=i,i=%d,p=%d\x1b\\", img_id, placement_id)
+	send_kitty_command(payload)
+end
+
+---Convert a non-PNG image file to PNG using ImageMagick (required by Kitty protocol)
+---@param path string Input file path
+---@return string|nil png_path Path to PNG file (same as input if already PNG, converted path otherwise)
+local function ensure_png(path)
+	-- Check if already PNG by reading magic bytes
+	local f = io.open(path, "rb")
+	if not f then
+		return nil
+	end
+	local header = f:read(8)
+	f:close()
+	if header and #header >= 4 and header:byte(1) == 0x89 and header:byte(2) == 0x50 and header:byte(3) == 0x4E
+		and header:byte(4) == 0x47
+	then
+		return path -- Already PNG
+	end
+
+	-- Convert to PNG via ImageMagick
+	local output_path = path .. ".png"
+	-- Try 'magick' (ImageMagick 7+) first, then 'convert' (ImageMagick 6)
+	for _, cmd_name in ipairs({ "magick", "convert" }) do
+		local cmd = string.format("%s '%s' '%s' 2>/dev/null", cmd_name, path, output_path)
+		os.execute(cmd)
+		-- Verify the output file was created
+		local check = io.open(output_path, "rb")
+		if check then
+			check:close()
+			return output_path
+		end
+	end
+	return nil
+end
+
+--------------------------------------------------------------------------------
+-- image.nvim Image object cache
+--------------------------------------------------------------------------------
+
+-- Storage for image.nvim Image objects (used for dimension reading and lifecycle)
 local image_cache = {} ---@type table<string, ImageNvim>
 
----Get or create an image.nvim Image object for a file path
+---Get or create an image.nvim Image object for a file path.
+---The Image provides pixel dimensions and a unique internal_id for Kitty protocol.
 ---@param path string Path to image file
 ---@return ImageNvim|nil
 local function get_or_create_image(path)
@@ -206,7 +313,9 @@ local function get_or_create_image(path)
 		return nil
 	end
 
-	local ok_from, img = pcall(image_api.from_file, path)
+	-- from_file reads dimensions via processor; requires setup() to have been called.
+	-- Pass id=path for deduplication so the same file reuses the existing Image.
+	local ok_from, img = pcall(image_api.from_file, path, { id = path })
 	if ok_from and img then
 		image_cache[path] = img
 		return img
@@ -214,37 +323,11 @@ local function get_or_create_image(path)
 	return nil
 end
 
----Send Kitty placement command to terminal
----@param img_id number Terminal image ID
----@param placement_id number Placement ID
----@param width number Width in terminal cells
----@param height number Height in terminal cells
-local function send_placement_request(img_id, placement_id, width, height)
-	local payload = string.format("\x1b_Ga=p,U=1,i=%d,p=%d,C=1,c=%d,r=%d\x1b\\", img_id, placement_id, width, height)
-	if vim.env.TMUX or vim.env.TMUX_PANE then
-		payload = "\x1bPtmux;\x1b" .. payload:gsub("\x1b", "\x1b\x1b") .. "\x1b\\"
-	end
-	io.stdout:write(payload)
-	io.stdout:flush()
-end
-
----Send Kitty delete placement command to terminal
----@param img_id number Terminal image ID
----@param placement_id number Placement ID
-local function send_clear_placement_request(img_id, placement_id)
-	local payload = string.format("\x1b_Ga=d,d=i,i=%d,p=%d\x1b\\", img_id, placement_id)
-	if vim.env.TMUX or vim.env.TMUX_PANE then
-		payload = "\x1bPtmux;\x1b" .. payload:gsub("\x1b", "\x1b\x1b") .. "\x1b\\"
-	end
-	io.stdout:write(payload)
-	io.stdout:flush()
-end
-
 --------------------------------------------------------------------------------
 -- Public API
 --------------------------------------------------------------------------------
 
----Check if image.nvim module is available
+---Check if image.nvim module is available and functional
 ---@return boolean
 function M.is_available()
 	local config = require("ipynb.config").get()
@@ -259,6 +342,15 @@ function M.is_available()
 	local ok, image_api = pcall(require, "image")
 	if not ok or not image_api then
 		return false
+	end
+
+	-- Verify image.nvim is actually set up by probing from_file.
+	-- from_file throws if setup() hasn't been called.
+	local probe_ok = pcall(image_api.from_file, "/dev/null")
+	if not probe_ok then
+		-- setup() hasn't been called; try to initialize with defaults.
+		-- Safe because the user's own setup() (if any) will re-initialize later.
+		pcall(image_api.setup, {})
 	end
 
 	image_available = true
@@ -347,13 +439,13 @@ function M.get_image_virt_lines(state, cell, output, image_index)
 	end
 
 	-- File content may have changed between executions for the same cell/image index.
-	-- Drop cached object so image.nvim reloads fresh bytes from disk.
+	-- Drop cached object so we reload fresh metadata from disk.
 	if image_cache[path] then
 		pcall(image_cache[path].clear, image_cache[path])
 		image_cache[path] = nil
 	end
 
-	-- Get or create image.nvim Image object
+	-- Get or create image.nvim Image object (for dimensions and Kitty image ID)
 	local img = get_or_create_image(path)
 	if not img then
 		return nil, 0
@@ -416,17 +508,23 @@ function M.get_image_virt_lines(state, cell, output, image_index)
 	img_width = math.max(1, img_width)
 	img_height = math.max(1, img_height)
 
-	-- Transmit image data to terminal via image.nvim
-	pcall(img.render, img, { width = img_width, height = img_height })
+	-- Ensure image is PNG for Kitty protocol (only f=100/PNG is standard)
+	local transmit_path = ensure_png(path)
+	if not transmit_path then
+		return nil, 0
+	end
 
-	-- Generate unique placement ID
-	local placement_id = next_placement_id()
+	-- Transmit image data to terminal via Kitty file reference.
+	-- NOTE: We do NOT call img:render() because that triggers image.nvim's own
+	-- display pipeline which sends a conflicting placement command.
 	local internal_id = img.internal_id or 1
+	send_transmit_request(internal_id, transmit_path)
 
-	-- Send placement command to terminal
+	-- Generate unique placement ID and send placement command
+	local placement_id = next_placement_id()
 	send_placement_request(internal_id, placement_id, img_width, img_height)
 
-	-- Generate placeholder grid lines
+	-- Generate placeholder grid lines (encodes image_id + placement_id in highlight)
 	local placeholder_lines, hl_group = generate_placeholder_grid(internal_id, placement_id, img_width, img_height)
 
 	-- Convert to virt_lines format
@@ -442,6 +540,7 @@ function M.get_image_virt_lines(state, cell, output, image_index)
 		img = img,
 		placement_id = placement_id,
 		path = path,
+		png_path = transmit_path ~= path and transmit_path or nil,
 	})
 
 	return virt_line_entries, img_height
@@ -456,16 +555,21 @@ function M.clear_images(state, cell_id)
 	end
 
 	for _, entry in ipairs(state.images[cell_id]) do
-		if entry.path then
-			if image_cache[entry.path] then
-				pcall(image_cache[entry.path].clear, image_cache[entry.path])
-				image_cache[entry.path] = nil
-			end
-			pcall(vim.fn.delete, entry.path)
+		-- Clear image.nvim Image from terminal and registry
+		if entry.img then
+			pcall(entry.img.clear, entry.img)
 		end
-		if entry.img and entry.placement_id then
-			local internal_id = entry.img.internal_id or 1
-			pcall(send_clear_placement_request, internal_id, entry.placement_id)
+		-- Remove from our local cache
+		if entry.path and image_cache[entry.path] then
+			image_cache[entry.path] = nil
+		end
+		-- Delete converted PNG if we created one
+		if entry.png_path then
+			pcall(vim.fn.delete, entry.png_path)
+		end
+		-- Delete the original cache file
+		if entry.path then
+			pcall(vim.fn.delete, entry.path)
 		end
 	end
 
@@ -493,4 +597,3 @@ function M.sync_positions(state)
 end
 
 return M
-

--- a/lua/ipynb/images.lua
+++ b/lua/ipynb/images.lua
@@ -1,33 +1,29 @@
--- ipynb/images.lua - Image output rendering using snacks.nvim
+-- ipynb/images.lua - Image output rendering using image.nvim
 -- Uses vendored placeholder generation for true text/image interleaving in virt_lines
 
 local M = {}
 
 --------------------------------------------------------------------------------
--- Type definitions for snacks.nvim (for LuaLS)
+-- Type definitions for image.nvim (for LuaLS)
 --------------------------------------------------------------------------------
 
----@class snacks.Image.Size
----@field width number
----@field height number
-
----@class snacks.Image.Info
----@field size snacks.Image.Size
-
----@class snacks.Image
----@field id number Image ID for terminal protocol
----@field info snacks.Image.Info|nil Image metadata (available after ready)
----@field ready fun(self: snacks.Image): boolean Check if image is ready
----@field failed fun(self: snacks.Image): boolean Check if image failed to load
+---@class ImageNvim
+---@field id string|number Image ID
+---@field internal_id number Image ID for terminal protocol
+---@field image_width number Pixel width
+---@field image_height number Pixel height
+---@field path string File path
+---@field render fun(self: ImageNvim, geometry?: table)
+---@field clear fun(self: ImageNvim, shallow?: boolean)
 
 --------------------------------------------------------------------------------
 
--- Namespace for our image extmarks (separate from snacks)
+-- Namespace for our image extmarks (separate from image.nvim)
 local ns = vim.api.nvim_create_namespace("ipynb_images")
 M.ns = ns
 
 --------------------------------------------------------------------------------
--- Vendored from snacks.nvim for placeholder generation
+-- Vendored from image placeholder generation for Kitty Graphics Protocol
 -- This allows us to generate image placeholder text for use in our own virt_lines
 --------------------------------------------------------------------------------
 
@@ -36,7 +32,7 @@ local PLACEHOLDER = vim.fn.nr2char(0x10EEEE)
 
 -- Diacritics used to encode row/column positions in placeholder cells
 -- stylua: ignore
-local diacritics = vim.split("0305,030D,030E,0310,0312,033D,033E,033F,0346,034A,034B,034C,0350,0351,0352,0357,035B,0363,0364,0365,0366,0367,0368,0369,036A,036B,036C,036D,036E,036F,0483,0484,0485,0486,0487,0592,0593,0594,0595,0597,0598,0599,059C,059D,059E,059F,05A0,05A1,05A8,05A9,05AB,05AC,05AF,05C4,0610,0611,0612,0613,0614,0615,0616,0617,0657,0658,0659,065A,065B,065D,065E,06D6,06D7,06D8,06D9,06DA,06DB,06DC,06DF,06E0,06E1,06E2,06E4,06E7,06E8,06EB,06EC,0730,0732,0733,0735,0736,073A,073D,073F,0740,0741,0743,0745,0747,0749,074A,07EB,07EC,07ED,07EE,07EF,07F0,07F1,07F3,0816,0817,0818,0819,081B,081C,081D,081E,081F,0820,0821,0822,0823,0825,0826,0827,0829,082A,082B,082C,082D,0951,0953,0954,0F82,0F83,0F86,0F87,135D,135E,135F,17DD,193A,1A17,1A75,1A76,1A77,1A78,1A79,1A7A,1A7B,1A7C,1B6B,1B6D,1B6E,1B6F,1B70,1B71,1B72,1B73,1CD0,1CD1,1CD2,1CDA,1CDB,1CE0,1DC0,1DC1,1DC3,1DC4,1DC5,1DC6,1DC7,1DC8,1DC9,1DCB,1DCC,1DD1,1DD2,1DD3,1DD4,1DD5,1DD6,1DD7,1DD8,1DD9,1DDA,1DDB,1DDC,1DDD,1DDE,1DDF,1DE0,1DE1,1DE2,1DE3,1DE4,1DE5,1DE6,1DFE,20D0,20D1,20D4,20D5,20D6,20D7,20DB,20DC,20E1,20E7,20E9,20F0,2CEF,2CF0,2CF1,2DE0,2DE1,2DE2,2DE3,2DE4,2DE5,2DE6,2DE7,2DE8,2DE9,2DEA,2DEB,2DEC,2DED,2DEE,2DEF,2DF0,2DF1,2DF2,2DF3,2DF4,2DF5,2DF6,2DF7,2DF8,2DF9,2DFA,2DFB,2DFC,2DFD,2DFE,2DFF,A66F,A67C,A67D,A6F0,A6F1,A8E0,A8E1,A8E2,A8E3,A8E4,A8E5,A8E6,A8E7,A8E8,A8E9,A8EA,A8EB,A8EC,A8ED,A8EE,A8EF,A8F0,A8F1,AAB0,AAB2,AAB3,AAB7,AAB8,AABE,AABF,AAC1,FE20,FE21,FE22,FE23,FE24,FE25,FE26,10A0F,10A38,1D185,1D186,1D187,1D188,1D189,1D1AA,1D1AB,1D1AC,1D1AD,1D242,1D243,1D244", ",")
+local diacritics = vim.split("0305,030D,030E,0310,0312,033D,033E,033F,0346,034A,034B,034C,0350,0351,0352,0357,035B,0363,0364,0365,0366,0367,0368,0369,036A,036B,036C,036D,036E,036F,0483,0484,0485,0486,0487,0592,0593,0594,0595,0597,0598,0599,059C,059D,059E,059F,05A0,05A1,05A8,05A9,05AB,05AC,05AF,05C4,0610,0611,0612,0613,0614,0615,0616,0617,0657,0658,0659,065A,065B,065D,065E,06D6,06D7,06D8,06D9,06DA,06DB,06DC,06DF,06E0,06E1,06E2,06E4,06E7,06E8,06EB,06EC,0730,0732,0733,0735,0736,073A,073D,073F,0740,0741,0743,0745,0747,0749,074A,07EB,07EC,07ED,07EE,07EF,07F0,07F1,07F3,0816,0817,0818,0819,081B,081C,081D,081E,081F,0820,0821,0822,0823,0825,0826,0827,0829,082A,082B,082C,082D,0951,0953,0954,0F82,0F83,0F86,0F87,135D,135E,135F,17DD,193A,1A17,1A75,1A76,1A77,1A78,1A79,1A7A,1A7B,1A7C,1B6B,1B6D,1B6E,1B6F,1B70,1B71,1B72,1B73,1CD0,1CD1,1CD2,1CDA,1CDB,1CE0,1DC0,1DC1,1DC3,1DC4,1DC5,1DC6,1DC7,1DC8,1DC9,1DCB,1DCC,1DD1,1DD2,1DD3,1DD4,1DD5,1DD6,1DD7,1DD8,1DD9,1DDA,1DDB,1DDC,1DDD,1DDE,1DDF,1DE0,1DE1,1DE2,1DE3,1DE4,1DE5,1DE6,1DFE,20D0,20D1,20D4,20D5,20D6,20D7,20DB,20DC,20E1,20E7,20E9,20F0,2CEF,2CF0,2CF1,2DE0,2DE1,2DE2,2DE3,2DE4,2DE5,2DE6,2DE7,2DE8,2DE9,2DEA,2DEB,2DEC,2DED,2DEE,2DEF,2DF0,2DF1,2DF2,2DF3,2DF4,2DF5,2DF6,2DF7,2DF8,2DF9,2DFA,2DFB,2DFC,2DFD,2DFF,A66F,A67C,A67D,A6F0,A6F1,A8E0,A8E1,A8E2,A8E3,A8E4,A8E5,A8E6,A8E7,A8E8,A8E9,A8EA,A8EB,A8EC,A8ED,A8EE,A8EF,A8F0,A8F1,AAB0,AAB2,AAB3,AAB7,AAB8,AABE,AABF,AAC1,FE20,FE21,FE22,FE23,FE24,FE25,FE26,10A0F,10A38,1D185,1D186,1D187,1D188,1D189,1D1AA,1D1AB,1D1AC,1D1AD,1D242,1D243,1D244", ",")
 
 -- Lazy-load diacritic characters
 ---@type table<number, string>
@@ -59,7 +55,7 @@ local function next_placement_id()
 end
 
 ---Generate placeholder grid lines for an image
----@param img_id number The snacks Image ID
+---@param img_id number The Image ID
 ---@param placement_id number The placement ID
 ---@param width number Width in terminal cells
 ---@param height number Height in terminal cells
@@ -117,8 +113,8 @@ local TEXT_MIME_TYPES = {
 	["image/svg+xml"] = true,
 }
 
--- Cache for snacks.nvim availability check
-local snacks_available = nil
+-- Cache for image.nvim availability check
+local image_available = nil
 
 ---Convert pixel dimensions to terminal cells
 ---@param width_px number|nil Width in pixels
@@ -130,11 +126,11 @@ local function pixels_to_cells(width_px, height_px)
 		return nil, nil
 	end
 
-	-- Get actual terminal cell dimensions from snacks
+	-- Get actual terminal cell dimensions from image.nvim if available
 	local cell_width, cell_height = 8, 16
-	local ok, Snacks = pcall(require, "snacks")
-	if ok and Snacks.image and Snacks.image.terminal then
-		local term_size = Snacks.image.terminal.size()
+	local ok, term = pcall(require, "image.utils.term")
+	if ok and term and term.get_size then
+		local term_size = term.get_size()
 		if term_size then
 			cell_width = term_size.cell_width or cell_width
 			cell_height = term_size.cell_height or cell_height
@@ -194,34 +190,61 @@ local function write_binary_file(path, data)
 	return ok_write ~= nil
 end
 
--- Storage for snacks Image objects (keep them alive for the terminal protocol)
-local image_cache = {} ---@type table<string, snacks.Image>
+-- Storage for image.nvim Image objects
+local image_cache = {} ---@type table<string, ImageNvim>
 
----Get or create a snacks Image object for a file path
+---Get or create an image.nvim Image object for a file path
 ---@param path string Path to image file
----@return snacks.Image|nil
+---@return ImageNvim|nil
 local function get_or_create_image(path)
 	if image_cache[path] then
 		return image_cache[path]
 	end
 
-	local ok, Snacks = pcall(require, "snacks")
-	if not ok then
+	local ok, image_api = pcall(require, "image")
+	if not ok or type(image_api.from_file) ~= "function" then
 		return nil
 	end
 
-	local img = Snacks.image.image.new(path)
-	if img then
+	local ok_from, img = pcall(image_api.from_file, path)
+	if ok_from and img then
 		image_cache[path] = img
+		return img
 	end
-	return img
+	return nil
+end
+
+---Send Kitty placement command to terminal
+---@param img_id number Terminal image ID
+---@param placement_id number Placement ID
+---@param width number Width in terminal cells
+---@param height number Height in terminal cells
+local function send_placement_request(img_id, placement_id, width, height)
+	local payload = string.format("\x1b_Ga=p,U=1,i=%d,p=%d,C=1,c=%d,r=%d\x1b\\", img_id, placement_id, width, height)
+	if vim.env.TMUX or vim.env.TMUX_PANE then
+		payload = "\x1bPtmux;\x1b" .. payload:gsub("\x1b", "\x1b\x1b") .. "\x1b\\"
+	end
+	io.stdout:write(payload)
+	io.stdout:flush()
+end
+
+---Send Kitty delete placement command to terminal
+---@param img_id number Terminal image ID
+---@param placement_id number Placement ID
+local function send_clear_placement_request(img_id, placement_id)
+	local payload = string.format("\x1b_Ga=d,d=i,i=%d,p=%d\x1b\\", img_id, placement_id)
+	if vim.env.TMUX or vim.env.TMUX_PANE then
+		payload = "\x1bPtmux;\x1b" .. payload:gsub("\x1b", "\x1b\x1b") .. "\x1b\\"
+	end
+	io.stdout:write(payload)
+	io.stdout:flush()
 end
 
 --------------------------------------------------------------------------------
 -- Public API
 --------------------------------------------------------------------------------
 
----Check if snacks.nvim image module is available
+---Check if image.nvim module is available
 ---@return boolean
 function M.is_available()
 	local config = require("ipynb.config").get()
@@ -229,36 +252,23 @@ function M.is_available()
 		return false
 	end
 
-	if snacks_available == true then
+	if image_available == true then
 		return true
 	end
 
-	local ok, Snacks = pcall(require, "snacks")
-	if not ok then
+	local ok, image_api = pcall(require, "image")
+	if not ok or not image_api then
 		return false
 	end
 
-	if not Snacks.image or not Snacks.image.placement then
-		return false
-	end
-
-	if Snacks.image.supports_terminal and not Snacks.image.supports_terminal() then
-		return false
-	end
-
-	snacks_available = true
+	image_available = true
 	return true
 end
 
 ---Check if terminal supports Unicode placeholders (required for virt_lines images)
 ---@return boolean
 function M.supports_placeholders()
-	if not M.is_available() then
-		return false
-	end
-	local Snacks = require("snacks")
-	local env = Snacks.image.terminal.env()
-	return env.placeholders == true
+	return M.is_available()
 end
 
 ---Check if output has any image data
@@ -308,7 +318,6 @@ function M.get_image_virt_lines(state, cell, output, image_index)
 		return nil, 0
 	end
 
-	local Snacks = require("snacks")
 	local cell_id = cell.id
 	if not cell_id then
 		return nil, 0
@@ -338,33 +347,25 @@ function M.get_image_virt_lines(state, cell, output, image_index)
 	end
 
 	-- File content may have changed between executions for the same cell/image index.
-	-- Drop cached object so snacks reloads fresh bytes from disk.
-	image_cache[path] = nil
+	-- Drop cached object so image.nvim reloads fresh bytes from disk.
+	if image_cache[path] then
+		pcall(image_cache[path].clear, image_cache[path])
+		image_cache[path] = nil
+	end
 
-	-- Get or create snacks Image (handles sending image data to terminal)
+	-- Get or create image.nvim Image object
 	local img = get_or_create_image(path)
 	if not img then
 		return nil, 0
 	end
 
-	-- Wait for image to be ready (it may need conversion)
-	local ready = vim.wait(500, function()
-		return img:ready() or img:failed()
-	end, 10)
-
-	if not ready or img:failed() then
+	-- Get dimensions from image.nvim Image
+	local native_width_px = img.image_width
+	local native_height_px = img.image_height
+	if not native_width_px or not native_height_px or native_width_px <= 0 or native_height_px <= 0 then
 		return nil, 0
 	end
 
-	-- Get dimensions from snacks' converted image
-	local native_width_px, native_height_px
-	if img.info and img.info.size then
-		native_width_px = img.info.size.width
-		native_height_px = img.info.size.height
-	end
-	if not native_width_px or not native_height_px then
-		return nil, 0
-	end
 	local native_width_cells, native_height_cells = pixels_to_cells(native_width_px, native_height_px)
 
 	-- Get config for size limits
@@ -415,22 +416,18 @@ function M.get_image_virt_lines(state, cell, output, image_index)
 	img_width = math.max(1, img_width)
 	img_height = math.max(1, img_height)
 
+	-- Transmit image data to terminal via image.nvim
+	pcall(img.render, img, { width = img_width, height = img_height })
+
 	-- Generate unique placement ID
 	local placement_id = next_placement_id()
+	local internal_id = img.internal_id or 1
 
 	-- Send placement command to terminal
-	Snacks.image.terminal.request({
-		a = "p",
-		U = 1,
-		i = img.id,
-		p = placement_id,
-		C = 1,
-		c = img_width,
-		r = img_height,
-	})
+	send_placement_request(internal_id, placement_id, img_width, img_height)
 
 	-- Generate placeholder grid lines
-	local placeholder_lines, hl_group = generate_placeholder_grid(img.id, placement_id, img_width, img_height)
+	local placeholder_lines, hl_group = generate_placeholder_grid(internal_id, placement_id, img_width, img_height)
 
 	-- Convert to virt_lines format
 	local virt_line_entries = {}
@@ -458,21 +455,17 @@ function M.clear_images(state, cell_id)
 		return
 	end
 
-	local ok, Snacks = pcall(require, "snacks")
-	if ok and Snacks.image and Snacks.image.terminal then
-		for _, entry in ipairs(state.images[cell_id]) do
-			if entry.path then
+	for _, entry in ipairs(state.images[cell_id]) do
+		if entry.path then
+			if image_cache[entry.path] then
+				pcall(image_cache[entry.path].clear, image_cache[entry.path])
 				image_cache[entry.path] = nil
-				pcall(vim.fn.delete, entry.path)
 			end
-			if entry.img and entry.placement_id then
-				pcall(Snacks.image.terminal.request, {
-					a = "d",
-					d = "i",
-					i = entry.img.id,
-					p = entry.placement_id,
-				})
-			end
+			pcall(vim.fn.delete, entry.path)
+		end
+		if entry.img and entry.placement_id then
+			local internal_id = entry.img.internal_id or 1
+			pcall(send_clear_placement_request, internal_id, entry.placement_id)
 		end
 	end
 
@@ -500,3 +493,4 @@ function M.sync_positions(state)
 end
 
 return M
+

--- a/lua/ipynb/output.lua
+++ b/lua/ipynb/output.lua
@@ -54,9 +54,9 @@ function M.render_output(output)
     local has_image = images_mod.get_image_data(output)
 
     if has_image then
-      -- Image will be rendered by snacks.nvim if available, skip text here to avoid extmark conflict
+      -- Image will be rendered by image.nvim if available, skip text here to avoid extmark conflict
       if not images_mod.is_available() then
-        table.insert(lines, { { '[Image output - install snacks.nvim to view]', 'Comment' } })
+        table.insert(lines, { { '[Image output - install image.nvim to view]', 'Comment' } })
       end
     else
       if output.data and output.data['text/plain'] then
@@ -81,14 +81,14 @@ function M.render_output(output)
     local has_image = images_mod.get_image_data(output)
 
     if has_image then
-      -- Image will be rendered inline if snacks.nvim available
+      -- Image will be rendered inline if image.nvim available
       if images_mod.is_available() then
         -- Show text/plain as caption above image (split by newlines)
         if output.data and output.data['text/plain'] then
           add_text_plain_lines(lines, output.data['text/plain'], nil, 'IpynbOutput')
         end
       else
-        table.insert(lines, { { '[Image output - install snacks.nvim to view]', 'Comment' } })
+        table.insert(lines, { { '[Image output - install image.nvim to view]', 'Comment' } })
       end
     else
       if output.data and output.data['text/plain'] then
@@ -128,7 +128,7 @@ function M.build_output_text(cell)
     elseif output.output_type == 'execute_result' then
       local has_image = images_mod.get_image_data(output)
       if has_image and not images_mod.is_available() then
-        table.insert(lines, '[Image output - install snacks.nvim to view]')
+        table.insert(lines, '[Image output - install image.nvim to view]')
       elseif output.data and output.data['text/plain'] then
         local text = to_string(output.data['text/plain'])
         for i, line in ipairs(vim.split(text, '\n', { plain = true })) do
@@ -171,7 +171,7 @@ function M.build_output_text(cell)
     elseif output.output_type == 'display_data' then
       local has_image = images_mod.get_image_data(output)
       if has_image and not images_mod.is_available() then
-        table.insert(lines, '[Image output - install snacks.nvim to view]')
+        table.insert(lines, '[Image output - install image.nvim to view]')
       elseif output.data and output.data['text/plain'] then
         local text = to_string(output.data['text/plain'])
         for _, line in ipairs(vim.split(text, '\n', { plain = true })) do


### PR DESCRIPTION
Snacks.nvim is only used for its image functionality. In this project, it requires anyone who downloads ipynb.nvim to have it downloaded.

This PR removes snacks.nvim and replaces it with images.nvim. 

I currently have it working with only kitty and ghostty. 